### PR TITLE
Parallels Desktop 9 compatibility

### DIFF
--- a/lib/vagrant-parallels/driver/prl_ctl.rb
+++ b/lib/vagrant-parallels/driver/prl_ctl.rb
@@ -178,7 +178,7 @@ module VagrantPlugins
 
         def read_settings(uuid=nil)
           uuid ||= @uuid
-          json({}) { execute('list', uuid, '--info', '--json', retryable: true).gsub(/^INFO\[/, '').gsub(/\]$/, '') }
+          json({}) { execute('list', uuid, '--info', '--json', retryable: true).gsub(/^(INFO)?\[/, '').gsub(/\]$/, '') }
         end
 
         def json(default=nil)


### PR DESCRIPTION
In Parallels Desktop 9 output of 'prlctl list --info --json <uuid>' does not contains word 'INFO' in the start of a line.
So, my edition make this function 'read_settings' workable in both Parallels Desktop 8 and 9 versions

This simple commit fixes issue #12
https://github.com/yshahin/vagrant-parallels/issues/12
