### PR TITLE
guest_capability added: 'mount_parallels_shared_folder'

### DIFF
--- a/lib/vagrant-parallels/action/share_folders.rb
+++ b/lib/vagrant-parallels/action/share_folders.rb
@@ -106,8 +106,17 @@ module VagrantPlugins
               @env[:ui].info(I18n.t("vagrant.actions.vm.share_folders.mounting_entry",
                                     :guest_path => data[:guestpath]))
 
-              # Symlink to mounted folder to guest path
-              @env[:machine].provider.driver.symlink(id, data[:guestpath])
+              # Dup the data so we can pass it to the guest API
+              data = data.dup
+
+              # Calculate the owner and group
+              ssh_info = @env[:machine].ssh_info
+              data[:owner] ||= ssh_info[:username]
+              data[:group] ||= ssh_info[:username]
+
+              # Mount the actual folder
+              @env[:machine].guest.capability(
+                :mount_parallels_shared_folder, id, data[:guestpath], data)
             else
               # If no guest path is specified, then automounting is disabled
               @env[:ui].info(I18n.t("vagrant.actions.vm.share_folders.nomount_entry",

--- a/lib/vagrant-parallels/driver/prl_ctl.rb
+++ b/lib/vagrant-parallels/driver/prl_ctl.rb
@@ -170,10 +170,6 @@ module VagrantPlugins
           end
         end
 
-        def symlink(id, path)
-          guest_execute('ln', '-sf', "/media/psf/#{id}", path)
-        end
-
         def execute_command(command)
           raw(*command)
         end

--- a/lib/vagrant-parallels/guest_cap/darwin/mount_parallels_shared_folder.rb
+++ b/lib/vagrant-parallels/guest_cap/darwin/mount_parallels_shared_folder.rb
@@ -1,0 +1,31 @@
+module VagrantPlugins
+  module Parallels
+    module GuestDarwinCap
+      class MountParallelsSharedFolder
+
+        def self.mount_parallels_shared_folder(machine, name, guestpath, options)
+          machine.communicate.tap do |comm|
+            # clear prior symlink
+            if comm.test("test -L \"#{guestpath}\"", :sudo => true)
+              comm.sudo("rm \"#{guestpath}\"")
+            end
+
+            # clear prior directory if exists
+            if comm.test("test -d \"#{guestpath}\"", :sudo => true)
+              comm.sudo("rm -Rf \"#{guestpath}\"")
+            end
+
+            # create intermediate directories if needed
+            intermediate_dir = File.dirname(guestpath)
+            if !comm.test("test -d \"#{intermediate_dir}\"", :sudo => true)
+              comm.sudo("mkdir -p \"#{intermediate_dir}\"")
+            end
+
+            # finally make the symlink
+            comm.sudo("ln -s \"/Volumes/SharedFolders/#{name}\" \"#{guestpath}\"")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
@@ -1,0 +1,31 @@
+module VagrantPlugins
+  module Parallels
+    module GuestLinuxCap
+      class MountParallelsSharedFolder
+
+        def self.mount_parallels_shared_folder(machine, name, guestpath, options)
+          machine.communicate.tap do |comm|
+            # clear prior symlink
+            if comm.test("test -L \"#{guestpath}\"", :sudo => true)
+              comm.sudo("rm \"#{guestpath}\"")
+            end
+
+            # clear prior directory if exists
+            if comm.test("test -d \"#{guestpath}\"", :sudo => true)
+              comm.sudo("rm -Rf \"#{guestpath}\"")
+            end
+
+            # create intermediate directories if needed
+            intermediate_dir = File.dirname(guestpath)
+            if !comm.test("test -d \"#{intermediate_dir}\"", :sudo => true)
+              comm.sudo("mkdir -p \"#{intermediate_dir}\"")
+            end
+
+            # finally make the symlink
+            comm.sudo("ln -s \"/media/psf/#{name}\" \"#{guestpath}\"")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -1,5 +1,3 @@
-require "vagrant"
-
 begin
   require "vagrant"
 rescue LoadError
@@ -70,6 +68,17 @@ module VagrantPlugins
       #   require File.expand_path("../config", __FILE__)
       #   Config
       # end
+
+      guest_capability(:darwin, :mount_parallels_shared_folder) do
+        require_relative "guest_cap/darwin/mount_parallels_shared_folder"
+        GuestDarwinCap::MountParallelsSharedFolder
+      end
+
+      guest_capability(:linux, :mount_parallels_shared_folder) do
+        require_relative "guest_cap/linux/mount_parallels_shared_folder"
+        GuestLinuxCap::MountParallelsSharedFolder
+      end
+
     end
 
     module Driver


### PR DESCRIPTION
Implement the enhancement described in #27  
It makes shared folders mounts available for different guests. Currently it works for any guests based on Linux and OS X 
