### PR TITLE
Fixed provider specific configuration to work on latest plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ It means that two public network adapters will be configured:
 1) The first will be bridged to the 'Wi-Fi' host machine's interface and will have the specified MAC address. After the VM boot it will be automatically configured to get an IP from the DHCP server, which is accessible in the 'Wi-Fi' network).
 2) The second adapter will be bridged to the interface 'en4' and will have static ip '10.3.1.18' and mask '255.255.252.0'.
 
+## Provider Specific Configuration
+
+Provider allows to define directives for `prlctl set` through `Vagrantfile` in same way as this done in VirtualBox provider.
+
+#### Example:
+```ruby
+    config.vm.provider :parallels do |parallels|
+    parallels.name = "HipHop VM"
+    parallels.customize ["set", :id, "--memsize", "1024"]
+```
+
 ## Development
 
 To work on the `vagrant-parallels` plugin, clone this repository out

--- a/lib/vagrant-parallels/driver/prl_ctl.rb
+++ b/lib/vagrant-parallels/driver/prl_ctl.rb
@@ -380,7 +380,7 @@ module VagrantPlugins
 
         # apply custom vm setting via set parameter
         def set_vm_settings(command)
-          raw(@manager_path, *command)
+          raw(@prlctl_path, *command)
         end
 
         def share_folders(folders)


### PR DESCRIPTION
As `@manager_path` have been removed, it was replaced by `@prlctl_path`. Also Added documentation changes to provide info for this feature.
