### PR TITLE
Fix missing "guest tools not detected" translation

### DIFF
--- a/lib/vagrant-parallels/action/check_guest_tools.rb
+++ b/lib/vagrant-parallels/action/check_guest_tools.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
         def call(env)
           tools_version = env[:machine].provider.driver.read_guest_tools_version
           if !tools_version
-            env[:ui].warn I18n.t("vagrant.actions.vm.check_guest_tools.not_detected")
+            env[:ui].warn I18n.t("vagrant_parallels.actions.vm.check_guest_tools.not_detected")
           else
             pd_version = env[:machine].provider.driver.version
             unless pd_version.start_with? tools_version


### PR DESCRIPTION
I was getting `[default] translation missing: en.vagrant.actions.vm.check_guest_tools.not_detected` until I made this change. Still have to figure out why the guest tools aren't being detected though.
