### PR TITLE
i18n-tasks: also scan vagrant keys

### DIFF
--- a/config/i18n-tasks.yml.erb
+++ b/config/i18n-tasks.yml.erb
@@ -10,3 +10,4 @@ data:
     - "locales/%{locale}.yml"
 ignore_unused:
   - "vagrant_parallels.errors.*"
+  - "vagrant.*"


### PR DESCRIPTION
Scan for missing `vagrant.*` keys, preventing a developer from using a non-existing key unknowingly.
`vagrant` keys are also added to `ignore_unused`. I will submit a PR to vagrant itself later to make sure there aren't any :) 
