### PR TITLE
Fix NFSNoHostonlyNetwork error since v0.2.2

### DIFF
--- a/lib/vagrant-parallels/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-parallels/action/prepare_nfs_settings.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
           @machine.provider.driver.read_network_interfaces.each do |adapter, opts|
             if opts[:type] == :hostonly
               @machine.provider.driver.read_host_only_interfaces.each do |interface|
-                if interface[:bound_to] == opts[:hostonly]
+                if interface[:name] == opts[:hostonly]
                   return adapter, interface[:ip]
                 end
               end

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
         #
         # @param [Hash] options Options to create the host only network.
         # @return [Hash] The details of the host only network, including
-        #   keys `:name`, `:bound_to`, `:ip`, `:netmask` and `:dhcp`
+        #   keys `:name`, `:ip`, `:netmask` and `:dhcp`
         def create_host_only_network(options)
         end
 
@@ -68,7 +68,7 @@ module VagrantPlugins
         # {
         #   :type     => :hostonly,
         #   :hostonly => "vagrant-vnet0",
-        #   :bound_to => "vnic2",
+        #   :name     => "vnic2",
         #   :nic_type => "virtio"
         # }
         #


### PR DESCRIPTION
- Regarding the commit 53065e9827

I have experienced NFSNoHostonlyNetwork error on using NFS synced folder with a boot2docker.box for Parallels which I made at https://github.com/YungSang/packer-parallels .

And then I found the deprecated "bound_to" parameter in the source code, which caused the error.

It will fix that and seems to work fine for me.
Please check it.
