### PR TITLE
Require version file

### DIFF
--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -10,6 +10,8 @@ if Vagrant::VERSION < "1.5.0"
   raise "The Vagrant Parallels plugin is only compatible with Vagrant 1.5+"
 end
 
+require_relative "version"
+
 module VagrantPlugins
   module Parallels
 


### PR DESCRIPTION
It seems to be good practice to require the version file with the plugin init and have the VERSION constant available globally. For example, [landrush](https://github.com/phinze/landrush/blob/master/lib/landrush/action/common.rb) (see line 44) needs the constant to do a comparison, which breaks currently.
