### PR TITLE
Fix hostonly network couldn't be found

### DIFF
--- a/lib/vagrant-parallels/action/network.rb
+++ b/lib/vagrant-parallels/action/network.rb
@@ -289,6 +289,7 @@ module VagrantPlugins
           end
 
           return {
+            name:        options[:name],
             adapter_ip:  options[:adapter_ip],
             auto_config: options[:auto_config],
             ip:          options[:ip],


### PR DESCRIPTION
Name parameter was not included in hostonly config options.
So host only network couldn't be found by Network ID.
This fixes it.
