### PR TITLE
Only skips SSH port forwarding for Parallels Desktop versions < 10

### DIFF
--- a/lib/vagrant-parallels/action/forward_ports.rb
+++ b/lib/vagrant-parallels/action/forward_ports.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
           @env = env
 
           # Get the ports we're forwarding
-          env[:forwarded_ports] ||= compile_forwarded_ports(env[:machine].config)
+          env[:forwarded_ports] ||= compile_forwarded_ports(env[:machine].config, env[:machine])
           env[:ui].output(I18n.t('vagrant.actions.vm.forward_ports.forwarding'))
           forward_ports
 

--- a/lib/vagrant-parallels/util/compile_forwarded_ports.rb
+++ b/lib/vagrant-parallels/util/compile_forwarded_ports.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
 
         # This method compiles the forwarded ports into {ForwardedPort}
         # models.
-        def compile_forwarded_ports(config)
+        def compile_forwarded_ports(config, machine)
           mappings = {}
 
           config.vm.networks.each do |type, options|
@@ -22,11 +22,8 @@ module VagrantPlugins
               # If the forwarded port was marked as disabled, ignore.
               next if options[:disabled]
 
-              # Temporary disable automatically pre-configured forwarded ports
-              # for SSH, since it is working not so well [GH-146]
-              # TODO: Roll it back when forwarded ports will be completely
-              # fixed in Parallels Desktop 10
-              next if id == 'ssh'
+              # Only port forward SSH for Parallels Desktop 10 (see [GH-146])
+              next if id == 'ssh' && !machine.provider.pd_version_satisfies?('>= 10')
 
               mappings[host_port.to_s + protocol.to_s] =
                 Model::ForwardedPort.new(id, host_port, guest_port, options)


### PR DESCRIPTION
This PR addresses issue #168 where the default SSH port forwarding is skipped for all versions of Parallels Desktop. We now check for the running version and dynamically make the decision to skip if the version is < 10.