### PR TITLE
Use MAC address of the first found Shared adapter

### DIFF
--- a/lib/vagrant-parallels/cap/nic_mac_addresses.rb
+++ b/lib/vagrant-parallels/cap/nic_mac_addresses.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
           nic_macs = machine.provider.driver.read_mac_addresses
 
           # Make numeration starting from 1, as it is expected in Vagrant.
-          Hash[nic_macs.map{ |index, mac| [index+1, mac] }]
+          Hash[nic_macs.map.with_index{ |mac, index| [index+1, mac] }]
         end
       end
     end

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -148,7 +148,7 @@ module VagrantPlugins
         def read_host_only_interfaces
         end
 
-        # Returns the MAC address of the first network interface.
+        # Returns the MAC address of the first Shared network interface.
         #
         # @return [String]
         def read_mac_address

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -154,9 +154,9 @@ module VagrantPlugins
         def read_mac_address
         end
 
-        # Returns the network interface card MAC addresses
+        # Returns the array of network interface card MAC addresses
         #
-        # @return [Hash<Integer, String>] Adapter => MAC address
+        # @return [Array<String>]
         def read_mac_addresses
         end
 

--- a/lib/vagrant-parallels/driver/pd_8.rb
+++ b/lib/vagrant-parallels/driver/pd_8.rb
@@ -306,7 +306,11 @@ module VagrantPlugins
           shared_ifaces = hw_info.select do |name, params|
             name.start_with?('net') && params['type'] == 'shared'
           end
-          
+
+          if shared_ifaces.empty?
+            raise Errors::SharedAdapterNotFound
+          end
+
           shared_ifaces.values.first.fetch('mac', nil)
         end
 

--- a/lib/vagrant-parallels/driver/pd_8.rb
+++ b/lib/vagrant-parallels/driver/pd_8.rb
@@ -307,8 +307,7 @@ module VagrantPlugins
         end
 
         def read_mac_addresses
-          macs = read_vm_option('mac').strip.split(' ')
-          Hash[macs.map.with_index{ |mac, ind| [ind, mac.gsub(':', '')] }]
+          read_vm_option('mac').strip.gsub(':', '').split(' ')
         end
 
         def read_network_interfaces

--- a/lib/vagrant-parallels/driver/pd_8.rb
+++ b/lib/vagrant-parallels/driver/pd_8.rb
@@ -302,8 +302,12 @@ module VagrantPlugins
         end
 
         def read_mac_address
-          # Get MAC of Shared network interface (net0)
-          read_vm_option('mac').strip.split(' ').first.gsub(':', '')
+          hw_info = read_settings.fetch('Hardware', {})
+          shared_ifaces = hw_info.select do |name, params|
+            name.start_with?('net') && params['type'] == 'shared'
+          end
+          
+          shared_ifaces.values.first.fetch('mac', nil)
         end
 
         def read_mac_addresses

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -55,6 +55,10 @@ module VagrantPlugins
         error_key(:parallels_vm_option_not_found)
       end
 
+      class SharedAdapterNotFound < VagrantParallelsError
+        error_key(:shared_adapter_not_found)
+      end
+
       class VMImportFailure < VagrantParallelsError
         error_key(:vm_import_failure)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -75,6 +75,10 @@ en:
         Could not find a required option of Parallels Desktop virtual machine:
           %{vm_option}
         This is an internal error that should be reported as a bug.
+      shared_adapter_not_found: |-
+        Shared network adapter was not found in your virtual machine configuration.
+        It is required to communicate with VM and forward ports. Please check
+        network configuration in your Vagrantfile.
       vm_import_failure: |-
         The VM import failed! Please verify that the box you're using is not
         corrupted and try again.

--- a/test/unit/support/shared/parallels_context.rb
+++ b/test/unit/support/shared/parallels_context.rb
@@ -223,7 +223,7 @@ shared_context 'parallels' do
     subprocess.stub(:execute).
       with('prlctl', 'list', kind_of(String), '--no-header', '-o', 'mac',
            kind_of(Hash)) do
-      subprocess_result(stdout: "001C42B4B074\n")
+      subprocess_result(stdout: "001C42B4B074 001C42B4B090\n")
     end
 
   end

--- a/test/unit/support/shared/parallels_context.rb
+++ b/test/unit/support/shared/parallels_context.rb
@@ -223,7 +223,7 @@ shared_context 'parallels' do
     subprocess.stub(:execute).
       with('prlctl', 'list', kind_of(String), '--no-header', '-o', 'mac',
            kind_of(Hash)) do
-      subprocess_result(stdout: "001C42B4B074 001C42B4B090\n")
+      subprocess_result(stdout: "00:1C:42:B4:B0:74 00:1C:42:B4:B0:90\n")
     end
 
   end

--- a/test/unit/support/shared/pd_driver_examples.rb
+++ b/test/unit/support/shared/pd_driver_examples.rb
@@ -186,9 +186,9 @@ shared_examples "parallels desktop driver" do |options|
 
   describe "read_mac_addresses" do
     it "returns MAC addresses of all network interface cards" do
-      subject.read_mac_addresses.should be_kind_of(Hash)
-      subject.read_mac_addresses.should include(0)
-      subject.read_mac_addresses[0].should be_kind_of(String)
+      subject.read_mac_addresses.should be_kind_of(Array)
+      subject.read_mac_addresses.should include('001C42B4B074')
+      subject.read_mac_addresses.should include('001C42B4B090')
     end
   end
 


### PR DESCRIPTION
This PR is going to help some folks to do tricky re-ordering of network interfaces: GH-185
In these cases "Shared" network adapter can have some other index, different from `net0`. So, we have to look at all network interfaces while doing the MAC address search.

If there is no "Shared" adapter found, then an error message will be displayed. It prevents ineffective "Waiting for the machine to boot", like GH-187

cc:\ @racktear @Gray-Wind 
