### PR TITLE
Let `util_path` return nil on failure

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -325,6 +325,7 @@ module VagrantPlugins
             path = File.join(folder, bin)
             return path if File.file?(path)
           end
+          nil
         end
 
       end


### PR DESCRIPTION
Array#each returns the [array] object it was invoked upon, so in case `util_path` doesn't find the executable, it would return the array `['/usr/local/bin', '/usr/bin']`, despite the rest of the code relies on it returning nil in case of failure.