### PR TITLE
Search installation path of Parallels Desktop

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -321,7 +321,7 @@ module VagrantPlugins
           path = Vagrant::Util::Which.which(bin)
           return path if path
 
-          ['/usr/local/bin', '/usr/bin'].each do |folder|
+          ['/usr/local/bin', '/usr/bin', '/Applications/Parallels Desktop.app/Contents/MacOS'].each do |folder|
             path = File.join(folder, bin)
             return path if File.file?(path)
           end


### PR DESCRIPTION
On my box, `prlctl` is neither in `/usr/local/bin/` nor `/usr/bin`, but rather in `/Applications/Parallels Desktop.app/Contents/MacOS`.