### PR TITLE
Feature pre-release: Linked clones support for Parallels Desktop 11

### DIFF
--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -84,7 +84,7 @@ module VagrantPlugins
           opts = {}
 
           # Linked clones are supported only for PD 11 and higher
-          if @machine.provider_config.linked_clone &&
+          if @machine.provider_config.use_linked_clone &&
             @machine.provider.pd_version_satisfies?('>= 11')
 
             env[:ui].info I18n.t('vagrant_parallels.actions.vm.import.importing_linked',

--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -89,6 +89,7 @@ module VagrantPlugins
 
             env[:ui].info I18n.t('vagrant_parallels.actions.vm.import.importing_linked',
                                  :name => @machine.box.name)
+            opts[:snapshot_id] = snapshot_id(tpl_name)
             opts[:linked] = true
           else
             env[:ui].info I18n.t("vagrant.actions.vm.import.importing",
@@ -113,6 +114,23 @@ module VagrantPlugins
             @logger.info("Regenerate SourceVmUuid")
             @machine.provider.driver.regenerate_src_uuid
           end
+        end
+
+        def snapshot_id(tpl_name)
+          snap_id = @machine.provider.driver.read_current_snapshot(tpl_name)
+
+          # If there is no current snapshot, just create the new one.
+          if !snap_id
+            @logger.info('Create a new snapshot')
+            opts = {
+              name: 'vagrant_linked_clone',
+              desc: 'Snapshot to create linked clones for Vagrant'
+            }
+            snap_id = @machine.provider.driver.create_snapshot(tpl_name, opts)
+          end
+
+          @logger.info("User this snapshot ID to create a linked clone: #{snap_id}")
+          snap_id
         end
 
         def unregister_template(tpl_name)

--- a/lib/vagrant-parallels/config.rb
+++ b/lib/vagrant-parallels/config.rb
@@ -6,6 +6,7 @@ module VagrantPlugins
       attr_accessor :destroy_unused_network_interfaces
       attr_accessor :functional_psf
       attr_accessor :optimize_power_consumption
+      attr_accessor :use_linked_clone
       attr_accessor :name
       attr_reader   :network_adapters
       attr_accessor :regen_src_uuid
@@ -22,6 +23,7 @@ module VagrantPlugins
         @customizations    = []
         @destroy_unused_network_interfaces = UNSET_VALUE
         @functional_psf = UNSET_VALUE
+        @use_linked_clone = UNSET_VALUE
         @network_adapters  = {}
         @name              = UNSET_VALUE
         @optimize_power_consumption = UNSET_VALUE
@@ -78,6 +80,8 @@ module VagrantPlugins
         if @optimize_power_consumption == UNSET_VALUE
           @optimize_power_consumption = true
         end
+
+        @use_linked_clone = false if @use_linked_clone == UNSET_VALUE
 
         @name = nil if @name == UNSET_VALUE
 

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -119,6 +119,14 @@ module VagrantPlugins
         def read_bridged_interfaces
         end
 
+        # Returns current snapshot ID for the specified VM. Returns nil if
+        # the VM doesn't have any snapshot.
+        #
+        # @param [String] uuid Name or UUID of the target VM.
+        # @return [String]
+        def read_current_snapshot(uuid)
+        end
+
         # Returns the state of guest tools that is installed on this VM.
         # Can be any of:
         # * "installed"

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -54,6 +54,14 @@ module VagrantPlugins
         def create_host_only_network(options)
         end
 
+        # Creates a snapshot for the specified virtual machine.
+        #
+        # @param [String] uuid Name or UUID of the target VM.
+        # @param [Hash] options Snapshot options.
+        # @return [String] ID of the created snapshot.
+        def create_snapshot(uuid, options)
+        end
+
         # Deletes the virtual machine references by this driver.
         def delete
         end

--- a/lib/vagrant-parallels/driver/meta.rb
+++ b/lib/vagrant-parallels/driver/meta.rb
@@ -80,6 +80,7 @@ module VagrantPlugins
                        :halt,
                        :clone_vm,
                        :read_bridged_interfaces,
+                       :read_current_snapshot,
                        :read_forwarded_ports,
                        :read_guest_ip,
                        :read_guest_tools_state,

--- a/lib/vagrant-parallels/driver/meta.rb
+++ b/lib/vagrant-parallels/driver/meta.rb
@@ -71,6 +71,7 @@ module VagrantPlugins
                        :clear_shared_folders,
                        :compact,
                        :create_host_only_network,
+                       :create_snapshot,
                        :delete,
                        :delete_disabled_adapters,
                        :delete_unused_host_only_networks,

--- a/lib/vagrant-parallels/driver/meta.rb
+++ b/lib/vagrant-parallels/driver/meta.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
             '8' => PD_8,
             '9' => PD_9,
             '10' => PD_10,
-            '11' => PD_10
+            '11' => PD_11
           }
 
           driver_klass = nil

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -1,0 +1,20 @@
+require 'log4r'
+
+require 'vagrant/util/platform'
+
+require File.expand_path('../pd_10', __FILE__)
+
+module VagrantPlugins
+  module Parallels
+    module Driver
+      # Driver for Parallels Desktop 11.
+      class PD_11 < PD_10
+        def initialize(uuid)
+          super(uuid)
+
+          @logger = Log4r::Logger.new('vagrant_parallels::driver::pd_11')
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -35,6 +35,19 @@ module VagrantPlugins
           read_vms[dst_name]
         end
 
+        def create_snapshot(uuid, options)
+          args = ['snapshot', uuid]
+          args.concat(['--name', options[:name]]) if options[:name]
+          args.concat(['--description', options[:desc]]) if options[:desc]
+
+          stdout = execute_prlctl(*args)
+          if stdout =~ /\{([\w-]+)\}/
+            return $1
+          end
+
+          raise Errors::SnapshotIdNotDetected, stdout: stdout
+        end
+
         def read_current_snapshot(uuid)
           if execute_prlctl('snapshot-list', uuid) =~ /\*\{([\w-]+)\}/
             return $1

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -24,11 +24,11 @@ module VagrantPlugins
           args << '--linked' if options[:linked]
           args.concat(['--id', options[:snapshot_id]]) if options[:snapshot_id]
 
-          execute_prlctl(*args) do |type, data|
-            lines = data.split("\r")
-            # The progress of the import will be in the last line. Do a greedy
+          execute_prlctl(*args) do |_, data|
+            lines = data.split('\r')
+            # The progress of the clone will be in the last line. Do a greedy
             # regular expression to find what we're looking for.
-            if lines.last =~ /.+?(\d{,3}) ?%/
+            if lines.last =~ /Copying hard disk.+?(\d{,3}) ?%/
               yield $1.to_i if block_given?
             end
           end

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -34,6 +34,14 @@ module VagrantPlugins
           end
           read_vms[dst_name]
         end
+
+        def read_current_snapshot(uuid)
+          if execute_prlctl('snapshot-list', uuid) =~ /\*\{([\w-]+)\}/
+            return $1
+          end
+
+          nil
+        end
       end
     end
   end

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -14,6 +14,26 @@ module VagrantPlugins
 
           @logger = Log4r::Logger.new('vagrant_parallels::driver::pd_11')
         end
+
+        def clone_vm(src_name, dst_name, options={})
+          args = ['clone', src_name, '--name', dst_name]
+          args << '--template' if options[:template]
+          args.concat(['--dst', options[:dst]]) if options[:dst]
+
+          # Linked clone options
+          args << '--linked' if options[:linked]
+          args.concat(['--id', options[:snapshot_id]]) if options[:snapshot_id]
+
+          execute_prlctl(*args) do |type, data|
+            lines = data.split("\r")
+            # The progress of the import will be in the last line. Do a greedy
+            # regular expression to find what we're looking for.
+            if lines.last =~ /.+?(\d{,3}) ?%/
+              yield $1.to_i if block_given?
+            end
+          end
+          read_vms[dst_name]
+        end
       end
     end
   end

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -59,6 +59,10 @@ module VagrantPlugins
         error_key(:shared_adapter_not_found)
       end
 
+      class SnapshotIdNotDetected < VagrantParallelsError
+        error_key(:snapshot_id_not_detected)
+      end
+
       class VMImportFailure < VagrantParallelsError
         error_key(:vm_import_failure)
       end

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -91,6 +91,7 @@ module VagrantPlugins
       autoload :PD_8, File.expand_path("../driver/pd_8", __FILE__)
       autoload :PD_9, File.expand_path("../driver/pd_9", __FILE__)
       autoload :PD_10, File.expand_path("../driver/pd_10", __FILE__)
+      autoload :PD_11, File.expand_path("../driver/pd_11", __FILE__)
     end
 
     module Model

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -164,3 +164,5 @@ en:
         forward_ports:
           forwarding_entry: |-
             %{guest_port} => %{host_port}
+        import:
+          importing_linked: Importing base box '%{name}' as a linked clone...

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -75,6 +75,11 @@ en:
         Could not find a required option of Parallels Desktop virtual machine:
           %{vm_option}
         This is an internal error that should be reported as a bug.
+      snapshot_id_not_detected: |-
+        ID of the newly created shapshod could not be detected. This is an
+        internal error that users should never see. Please report a bug.
+
+        stdout: %{stdout}
       shared_adapter_not_found: |-
         Shared network adapter was not found in your virtual machine configuration.
         It is required to communicate with VM and forward ports. Please check

--- a/test/acceptance/provider/linked_clone_spec.rb
+++ b/test/acceptance/provider/linked_clone_spec.rb
@@ -1,0 +1,26 @@
+# This tests that VM is up as a linked clone
+shared_examples 'provider/linked_clone' do |provider, options|
+  if !options[:box]
+    raise ArgumentError,
+      "box option must be specified for provider: #{provider}"
+  end
+
+  include_context 'acceptance'
+
+  before do
+    environment.skeleton('linked_clone')
+    assert_execute('vagrant', 'box', 'add', 'basic', options[:box])
+    assert_execute('vagrant', 'up', "--provider=#{provider}")
+  end
+
+  after do
+    assert_execute('vagrant', 'destroy', '--force')
+  end
+
+  it 'creates machine as linked clone' do
+    status("Test: machine is running after up")
+    result = execute("vagrant", "ssh", "-c", "echo foo")
+    expect(result).to exit_with(0)
+    expect(result.stdout).to match(/foo\n$/)
+  end
+end

--- a/test/acceptance/skeletons/linked_clone/Vagrantfile
+++ b/test/acceptance/skeletons/linked_clone/Vagrantfile
@@ -1,0 +1,7 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "basic"
+
+  config.vm.provider "parallels" do |prl|
+    prl.use_linked_clone = true
+  end
+end


### PR DESCRIPTION
*NB! This feature will be available officially only after Parallels Desktop 11 release*

It is called "Create VM as a linked clone", e.q. on the first `vagrant up` the virtual machine will be created as a linked clone of the box image. 

#### "Linked" vs "regular" clones:
- Regular clone is a full image copy, which is independent from the box. The linked clone is bounded to the specific snapshot of the box image. It means that box deletion will cause all its linked clones being corrupted!
- Linked clone creation is extremely faster than the regular cloning, because there is no image copying process.
- Linked clones require much less disk space, because initially hard disk image size is less than 1Mb (it is bounded to the parent's snapshot)

#### How to use
This feature is disabled by default, e.q. the VM creation is performed through the regular cloning, as before. To enable linked clone, just add this parameter:
```ruby
config.vm.provider "parallels" do |prl|
  prl.use_linked_clone = true
end
```
*It works only with Parallels Desktop 11, which is not released yet!*

cc:\ @racktear @Gray-Wind 