### PR TITLE
Use most recent DHCP lease when determining an IP

### DIFF
--- a/test/unit/driver/pd_8_test.rb
+++ b/test/unit/driver/pd_8_test.rb
@@ -7,25 +7,4 @@ describe VagrantPlugins::Parallels::Driver::PD_8 do
   subject { VagrantPlugins::Parallels::Driver::Meta.new(uuid) }
 
   it_behaves_like "parallels desktop driver"
-
-  describe "ssh_ip" do
-    let(:content) {'10.200.0.100="1394546410,1800,001c420000ff,01001c420000ff
-                    10.200.0.99="1394547632,1800,001c420000ff,01001c420000ff"'}
-
-    it "returns an IP address assigned to the specified MAC" do
-      driver.should_receive(:read_mac_address).and_return("001C420000FF")
-      File.should_receive(:open).with(an_instance_of(String)).
-        and_return(StringIO.new(content))
-
-      subject.ssh_ip.should == "10.200.0.99"
-    end
-
-    it "rises DhcpLeasesNotAccessible exception when file is not accessible" do
-      File.stub(:open).and_call_original
-      File.should_receive(:open).with(an_instance_of(String)).
-        and_raise(Errno::EACCES)
-      expect { subject.ssh_ip }.
-        to raise_error(VagrantPlugins::Parallels::Errors::DhcpLeasesNotAccessible)
-    end
-  end
 end

--- a/test/unit/driver/pd_8_test.rb
+++ b/test/unit/driver/pd_8_test.rb
@@ -9,7 +9,8 @@ describe VagrantPlugins::Parallels::Driver::PD_8 do
   it_behaves_like "parallels desktop driver"
 
   describe "ssh_ip" do
-    let(:content) {'10.200.0.99="1394547632,1800,001c420000ff,01001c420000ff"'}
+    let(:content) {'10.200.0.100="1394546410,1800,001c420000ff,01001c420000ff
+                    10.200.0.99="1394547632,1800,001c420000ff,01001c420000ff"'}
 
     it "returns an IP address assigned to the specified MAC" do
       driver.should_receive(:read_mac_address).and_return("001C420000FF")

--- a/test/unit/driver/pd_9_test.rb
+++ b/test/unit/driver/pd_9_test.rb
@@ -28,7 +28,8 @@ describe VagrantPlugins::Parallels::Driver::PD_9 do
   end
 
   describe "ssh_ip" do
-    let(:content) {'10.200.0.99="1394547632,1800,001c420000ff,01001c420000ff"'}
+    let(:content) {'10.200.0.100="1394546410,1800,001c420000ff,01001c420000ff
+                    10.200.0.99="1394547632,1800,001c420000ff,01001c420000ff"'}
 
     it "returns an IP address assigned to the specified MAC" do
       driver.should_receive(:read_mac_address).and_return("001C420000FF")

--- a/test/unit/driver/pd_9_test.rb
+++ b/test/unit/driver/pd_9_test.rb
@@ -26,26 +26,4 @@ describe VagrantPlugins::Parallels::Driver::PD_9 do
       subject.set_power_consumption_mode(false)
     end
   end
-
-  describe "ssh_ip" do
-    let(:content) {'10.200.0.100="1394546410,1800,001c420000ff,01001c420000ff
-                    10.200.0.99="1394547632,1800,001c420000ff,01001c420000ff"'}
-
-    it "returns an IP address assigned to the specified MAC" do
-      driver.should_receive(:read_mac_address).and_return("001C420000FF")
-      File.should_receive(:open).with(an_instance_of(String)).
-        and_return(StringIO.new(content))
-
-      subject.ssh_ip.should == "10.200.0.99"
-    end
-
-    it "rises DhcpLeasesNotAccessible exception when file is not accessible" do
-      File.stub(:open).and_call_original
-      File.should_receive(:open).with(an_instance_of(String)).
-        and_raise(Errno::EACCES)
-      expect { subject.ssh_ip }.
-        to raise_error(VagrantPlugins::Parallels::Errors::DhcpLeasesNotAccessible)
-    end
-  end
-
 end

--- a/test/unit/support/shared/pd_driver_examples.rb
+++ b/test/unit/support/shared/pd_driver_examples.rb
@@ -269,6 +269,27 @@ shared_examples "parallels desktop driver" do |options|
     end
   end
 
+  describe "ssh_ip" do
+    let(:content) {'10.200.0.100="1394546410,1800,001c420000ff,01001c420000ff
+                    10.200.0.99="1394547632,1800,001c420000ff,01001c420000ff"'}
+
+    it "returns an IP address assigned to the specified MAC" do
+      driver.should_receive(:read_mac_address).and_return("001C420000FF")
+      File.should_receive(:open).with(an_instance_of(String)).
+        and_return(StringIO.new(content))
+
+      subject.ssh_ip.should == "10.200.0.99"
+    end
+
+    it "rises DhcpLeasesNotAccessible exception when file is not accessible" do
+      File.stub(:open).and_call_original
+      File.should_receive(:open).with(an_instance_of(String)).
+        and_raise(Errno::EACCES)
+      expect { subject.ssh_ip }.
+        to raise_error(VagrantPlugins::Parallels::Errors::DhcpLeasesNotAccessible)
+    end
+  end
+
   describe "start" do
     it "starts the VM" do
       subprocess.should_receive(:execute).


### PR DESCRIPTION
Fixes [GH-194]
In some cases there are multiple DHCP leases for one network interface, so we should use the most recent lease.