### PR TITLE
docs: Replace “memory” with “memsize”

### DIFF
--- a/website/docs/source/docs/configuration.html.md
+++ b/website/docs/source/docs/configuration.html.md
@@ -136,7 +136,7 @@ A simple way is provided to change the memory and CPU settings:
 
 ```ruby
 config.vm.provider "parallels" do |prl|
-  prl.memory = 1024
+  prl.memsize = 1024
   prl.cpus = 2
 end
 ```


### PR DESCRIPTION
Just fixing a small typo.