### PR TITLE
driver: Retry to parse json

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -670,7 +670,13 @@ module VagrantPlugins
         # Parses given block (JSON string) to object
         def json(default=nil)
           data = yield
-          JSON.parse(data) rescue default
+          begin
+            JSON.parse(data)
+          rescue JSON::ParserError
+            # Try to cleanup the data and parse it again [GH-204]
+            data = data[/(\{.*\}|\[.*\])/m]
+            JSON.parse(data) rescue default
+          end
         end
 
         # Executes a command and returns the raw result object.


### PR DESCRIPTION
Fixes GH-204
This is a workaround for the case when `prlsrvctl --json` contains messy symbols.
We should try to fetch JSON string using the regexp and try to parse it again.

cc: @racktear @Gray-Wind 