### PR TITLE
Disable password restrictions before #import and #destroy actions

### DIFF
--- a/lib/vagrant-parallels/action/destroy.rb
+++ b/lib/vagrant-parallels/action/destroy.rb
@@ -4,9 +4,17 @@ module VagrantPlugins
       class Destroy
         def initialize(app, env)
           @app = app
+          @logger = Log4r::Logger.new('vagrant_parallels::action::destroy')
         end
 
         def call(env)
+          # Disable requiring password for delete action [GH-67].
+          # It is available only since PD 10.
+          if env[:machine].provider.pd_version_satisfies?('>= 10')
+            @logger.info('Disabling password restrictions: remove-vm')
+            env[:machine].provider.driver.disable_password_restrictions(['remove-vm'])
+          end
+
           env[:ui].info I18n.t('vagrant.actions.vm.destroy.destroying')
           env[:machine].provider.driver.delete
           env[:machine].id = nil

--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -12,6 +12,14 @@ module VagrantPlugins
         def call(env)
           @machine = env[:machine]
 
+          # Disable requiring password for register and clone actions [GH-67].
+          # It is available only since PD 10.
+          if env[:machine].provider.pd_version_satisfies?('>= 10')
+            acts = ['clone-vm']
+            @logger.info("Disabling password restrictions: #{acts.join(', ')}")
+            env[:machine].provider.driver.disable_password_restrictions(acts)
+          end
+
           # Register template to be able to clone it further
           register_template(template_path.to_s)
 

--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -14,14 +14,6 @@ module VagrantPlugins
           # helpers.
           @env = env
 
-          # Disable requiring password on such operations as creating, adding,
-          # removing or coning the virtual machine. [GH-67]
-          # It is available only since PD 10.
-          if env[:machine].provider.pd_version_satisfies?('>= 10')
-            @logger.info('Disabling any password restrictions...')
-            env[:machine].provider.driver.disable_password_restrictions
-          end
-
           if env[:machine].provider.pd_version_satisfies?('>= 9')
             @logger.info('Setting the power consumption mode...')
             set_power_consumption

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -156,7 +156,9 @@ module VagrantPlugins
         # Disables requiring password on such operations as creating, adding,
         # removing or cloning the virtual machine.
         #
-        def disable_password_restrictions
+        # @param [Array<String>] acts List of actions. Available values:
+        # ['create-vm', 'add-vm', 'remove-vm', 'clone-vm']
+        def disable_password_restrictions(acts)
           raise NotImplementedError
         end
 

--- a/lib/vagrant-parallels/driver/pd_10.rb
+++ b/lib/vagrant-parallels/driver/pd_10.rb
@@ -49,10 +49,10 @@ module VagrantPlugins
           end
         end
 
-        def disable_password_restrictions
+        def disable_password_restriction(acts)
           server_info = json { execute_prlsrvctl('info', '--json') }
           server_info.fetch('Require password to',[]).each do |act|
-            execute_prlsrvctl('set', '--require-pwd', "#{act}:off")
+            execute_prlsrvctl('set', '--require-pwd', "#{act}:off") if acts.include? act
           end
         end
 


### PR DESCRIPTION
Fixes #178

Previously, `disable_password_restrictions ` was useless because it was called after the `Import` action.
I've fixed that by moving it directly to `Import` and `Destroy` actions