### PR TITLE
Set default configuration for VM right after Import action

### DIFF
--- a/lib/vagrant-parallels/action.rb
+++ b/lib/vagrant-parallels/action.rb
@@ -24,7 +24,6 @@ module VagrantPlugins
           b.use ClearNetworkInterfaces
           b.use ForwardPorts
           b.use SetHostname
-          b.use SaneDefaults
           b.use Customize, 'pre-boot'
           b.use Boot
           b.use Customize, 'post-boot'
@@ -278,6 +277,7 @@ module VagrantPlugins
             if env1[:result]
               b1.use Customize, 'pre-import'
               b1.use Import
+              b1.use SaneDefaults
               b1.use Customize, 'post-import'
             end
           end

--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -14,31 +14,7 @@ module VagrantPlugins
           # helpers.
           @env = env
 
-          if env[:machine].provider.pd_version_satisfies?('>= 9')
-            @logger.info('Setting the power consumption mode...')
-            set_power_consumption
-          end
-
           @app.call(env)
-        end
-
-        private
-
-        def set_power_consumption
-          # Optimization of power consumption is defined by "Longer Battery Life" state.
-          vm_settings = @env[:machine].provider.driver.read_settings
-
-          old_val = vm_settings.fetch('Longer battery life') == 'on' ? true : false
-          new_val = @env[:machine].provider_config.optimize_power_consumption
-
-          if old_val == new_val
-            @logger.info('Skipping power consumption method because it is already set')
-          else
-            mode = new_val ? 'Longer battery life' : 'Better Performance'
-            @env[:ui].info I18n.t('vagrant_parallels.parallels.power_consumption.set_mode',
-                                  mode: mode)
-            @env[:machine].provider.driver.set_power_consumption_mode(new_val)
-          end
         end
       end
     end

--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -14,7 +14,57 @@ module VagrantPlugins
           # helpers.
           @env = env
 
+          settings = default_settings
+
+          @app.call(env) if settings.empty?
+          @env[:ui].info I18n.t('vagrant_parallels.actions.vm.sane_defaults.setting')
+
+          default_settings.each do |setting, value|
+            @env[:machine].provider.driver.execute_prlctl(
+              'set', @env[:machine].id, "--#{setting.to_s.gsub('_','-')}", value)
+          end
+
           @app.call(env)
+        end
+
+        private
+
+        def default_settings
+          settings = {}
+
+          return settings if @env[:machine].provider.pd_version_satisfies?('< 9')
+          settings.merge!(
+            startup_view: 'same',
+            on_shutdown: 'close',
+            on_window_close: 'keep-running',
+            auto_share_camera: 'off',
+            smart_guard: 'off',
+            longer_battery_life: 'on'
+          )
+
+          # Check the legacy option
+          if !@env[:machine].provider_config.optimize_power_consumption
+            settings[:longer_battery_life] = 'off'
+          end
+
+          return settings  if @env[:machine].provider.pd_version_satisfies?('< 10.1.2')
+          settings.merge!(
+            shared_cloud: 'off',
+            shared_profile: 'off',
+            smart_mount: 'off',
+            sh_app_guest_to_host: 'off',
+            sh_app_host_to_guest: 'off',
+            time_sync: 'off'
+          )
+
+          return settings if @env[:machine].provider.pd_version_satisfies?('< 11')
+          settings.merge!(
+            startup_view: 'headless',
+            time_sync: 'on',
+            disable_timezone_sync: 'on'
+          )
+
+          settings
         end
       end
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,9 +1,6 @@
 en:
   vagrant_parallels:
     parallels:
-      power_consumption:
-        set_mode: |-
-          Setting power consumption mode: "%{mode}"
       network_adapter: |-
         Adapter %{adapter}: %{type}%{extra}
 #-------------------------------------------------------------------------------
@@ -186,3 +183,5 @@ en:
             %{guest_port} => %{host_port}
         import:
           importing_linked: Importing base box '%{name}' as a linked clone...
+        sane_defaults:
+          setting: Setting the default configuration for VM...


### PR DESCRIPTION
Fixes #186, #182, #124, #39 

This PR adds a new behavior to the initial `vagrant up`. There are a bunch of default settings which will be applied to each new virtual machine. 

These settings will be applied only once, right after the VM is cloned (after `Import` action). So that, user will be able to override them manually (via GUI or `prlctl`) or using the `customize` settings in Vagrantfile:

```ruby
config.vm.provider "parallels" do |prl|
  prl.customize ["set", :id, "--startup-view", "window"]
  prl.customize ["set", :id, "--on-window-close", "suspend"]
  #...
end
```

## List of default settings:
These are options for `prlctl set <vm_uuid> ...` 

1. For Parallels Desktop >= 9:
`--startup-view same`
`--on-shutdown close`
`--on-window-close keep-running`
`--auto-share-camera off`
`--smart-guard off`
`--longer-battery-life on`

2. Also, for Parallels Desktop >= 10.1.2:
_(All previously mentioned for PD 9)_
`--shared-cloud off`
`--shared-profile off`
`--smart-mount off`
`--sh-app-guest-to-host off`
`--sh-app-host-to-guest off`
`--time-sync off`

3. Also, for Parallels Desktop >= 11
_(All previously mentioned for PD 9 and PD 10.1.2)_
`--startup-view headless`
`--time-sync on`
`--disable-timezone-sync on`

cc: @racktear @Gray-Wind