### PR TITLE
Deprecate "optimize_power_consumption" setting

### DIFF
--- a/lib/vagrant-parallels/config.rb
+++ b/lib/vagrant-parallels/config.rb
@@ -77,10 +77,6 @@ module VagrantPlugins
           @functional_psf = true
         end
 
-        if @optimize_power_consumption == UNSET_VALUE
-          @optimize_power_consumption = true
-        end
-
         @use_linked_clone = false if @use_linked_clone == UNSET_VALUE
 
         @name = nil if @name == UNSET_VALUE
@@ -106,6 +102,10 @@ module VagrantPlugins
           if event == 'pre-import' && command.index(:id)
             errors << I18n.t('vagrant_parallels.config.id_in_pre_import')
           end
+        end
+
+        if @optimize_power_consumption != UNSET_VALUE
+          machine.env.ui.warn I18n.t('vagrant_parallels.config.deprecate_power_consumption')
         end
 
         { 'Parallels Provider' => errors }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -114,6 +114,17 @@ en:
       invalid_event: |-
         %{event} is not a valid event for customization. Valid events
         are: %{valid_events}
+      deprecate_power_consumption: |-
+        Setting "optimize_power_consumption" has been deprecated in the Parallels
+        provider and will be removed in the future releases. Power consumption
+        is enabled by default. If you want to keep it enabled, then just remove
+        this setting from your Vagrantfile. Otherwise, please replace it with
+        this block in order to disable the power consumption:
+
+          config.vm.provider "parallels" do |prl|
+            prl.customize ["set", :id, "--longer-battery-life", "off"]
+          end
+
 #-------------------------------------------------------------------------------
 # Translations for commands. e.g. `vagrant x`
 #-------------------------------------------------------------------------------

--- a/website/docs/source/docs/configuration.html.md
+++ b/website/docs/source/docs/configuration.html.md
@@ -95,20 +95,6 @@ end
 In this case the both of Parallels Tools status check and an automatic update
 procedure will be skipped as well.
 
-## Power Consumption Mode
-The Parallels provider sets power consumption method as "Longer Battery 
-Life" by default. You can override it to "Better Performance" using this 
-customisation parameter:
-
-```ruby
-config.vm.provider "parallels" do |prl| 
-  prl.optimize_power_consumption = false
-end
-```
-
-P.s. Read more about power consumption modes in Parallels Desktop: [KB #9607]
-(http://kb.parallels.com/en/9607)
-
 ## Customization with prlctl
 
 Parallels Desktop includes the `prlctl` command-line utility that can be used to


### PR DESCRIPTION
We decide to manage all VM options with the single approach, using `customize`, like this:

```ruby
config.vm.provider "parallels" do |prl|
  prl.customize ["set", :id, "--longer-battery-life", "off"]
end
```

Related to changed introduced by GH-215