### PR TITLE
Escape colon in synced folder id

### DIFF
--- a/lib/vagrant-parallels/synced_folder.rb
+++ b/lib/vagrant-parallels/synced_folder.rb
@@ -105,7 +105,7 @@ module VagrantPlugins
       end
 
       def os_friendly_id(id)
-        id.gsub(/[\/]/,'_').sub(/^_/, '')
+        id.gsub(/[\/:]/,'_').sub(/^_/, '')
       end
     end
   end


### PR DESCRIPTION
This is a actual for Windows guests, where colon is the part of any absolute path.
Parallels Desktop replaces colons (:) by asterisks (*) on the guest side, which breaks the synced folder
mapping for Vagrant.

Fixes GH-220
