### PR TITLE
Retry JSON parsing and display readble error if it is failed

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -678,7 +678,9 @@ module VagrantPlugins
             JSON.parse(data)
           rescue JSON::JSONError
             # We retried already, raise the issue and be done
-            raise if raise_error
+            if raise_error
+              raise VagrantPlugins::Parallels::Errors::JSONParseError, data: data
+            end
 
             # Remove garbage before/after json string[GH-204]
             data = data[/(\{.*\}|\[.*\])/m]

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -454,8 +454,8 @@ module VagrantPlugins
         # @return [<String => String>]
         def read_vms
           args = %w(list --all --no-header --json -o name,uuid)
-          vms_arr = json([]) { execute_prlctl(*args) }
-          templates_arr = json([]) { execute_prlctl(*args, '--template') }
+          vms_arr = json { execute_prlctl(*args) }
+          templates_arr = json { execute_prlctl(*args, '--template') }
 
           vms = vms_arr | templates_arr
           Hash[vms.map { |i| [i.fetch('name'), i.fetch('uuid')] }]
@@ -466,8 +466,8 @@ module VagrantPlugins
         # @return [Array <String => String>]
         def read_vms_info
           args = %w(list --all --info --no-header --json)
-          vms_arr = json([]) { execute_prlctl(*args) }
-          templates_arr = json([]) { execute_prlctl(*args, '--template') }
+          vms_arr = json { execute_prlctl(*args) }
+          templates_arr = json { execute_prlctl(*args, '--template') }
 
           vms_arr | templates_arr
         end
@@ -670,7 +670,7 @@ module VagrantPlugins
         end
 
         # Parses given block (JSON string) to object
-        def json(default=nil)
+        def json
           data = yield
           raise_error = false
 

--- a/lib/vagrant-parallels/driver/meta.rb
+++ b/lib/vagrant-parallels/driver/meta.rb
@@ -117,7 +117,7 @@ module VagrantPlugins
         #
         # @return [String]
         def read_edition
-          lic_info = json({}) do
+          lic_info = json do
             execute(@prlsrvctl_path, 'info', '--license', '--json')
           end
           lic_info['edition']

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -11,6 +11,10 @@ module VagrantPlugins
         error_key(:dhcp_leases_file_not_accessible)
       end
 
+      class JSONParseError < VagrantParallelsError
+        error_key(:json_parse_error)
+      end
+
       class LinuxMountFailed < VagrantParallelsError
         error_key(:linux_mount_failed)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -20,6 +20,12 @@ en:
 
         Stderr: %{stderr}
 
+      json_parse_error: |-
+        Failed to parse the JSON string! Please report this as a bug of Parallels
+        provider: https://github.com/Parallels/vagrant-parallels/issues
+        JSON string is shown below:
+
+        %{data}
       linux_mount_failed: |-
         Failed to mount folders in Linux guest. This is usually because
         the "prl_fs" file system is not available. Please verify that


### PR DESCRIPTION
This PR fixes issue GH-219 (or at least minimizes the chance of occurrence).

Sometimes some non-valid characters could be in the json-formatted output `prlctl` and `prlsrvctl` utilities. It causes a human unfriendly exception like described in GH-219.

This PR changes the following:
1) `json` method doesn't support default return value. It will either return the parsed Ruby data structure, or will raise a human-friendly error.
2) Before raising an error it will try to trim all control characters unsupported by JSON (from `\u0000` to `u001f`).

cc: @racktear @Gray-Wind 