### PR TITLE
Support core feature `config.vm.clone`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git', tag: 'v1.7.4'
+  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git'
   gem 'vagrant-spec', git: 'git://github.com/mitchellh/vagrant-spec.git'
 end

--- a/lib/vagrant-parallels/action.rb
+++ b/lib/vagrant-parallels/action.rb
@@ -276,7 +276,9 @@ module VagrantPlugins
             # If the VM is NOT created yet, then do the setup steps
             if env1[:result]
               b1.use Customize, 'pre-import'
+              b1.use BoxRegister
               b1.use Import
+              b1.use BoxUnregister
               b1.use SaneDefaults
               b1.use Customize, 'post-import'
             end
@@ -330,6 +332,8 @@ module VagrantPlugins
 
 
       autoload :Boot, File.expand_path('../action/boot', __FILE__)
+      autoload :BoxRegister, File.expand_path('../action/box_register', __FILE__)
+      autoload :BoxUnregister, File.expand_path('../action/box_unregister', __FILE__)
       autoload :HandleGuestTools, File.expand_path('../action/handle_guest_tools', __FILE__)
       autoload :HandleForwardedPortCollisions, File.expand_path('../action/handle_forwarded_port_collisions.rb', __FILE__)
       autoload :ClearNetworkInterfaces, File.expand_path('../action/clear_network_interfaces', __FILE__)

--- a/lib/vagrant-parallels/action.rb
+++ b/lib/vagrant-parallels/action.rb
@@ -277,6 +277,8 @@ module VagrantPlugins
             if env1[:result]
               b1.use Customize, 'pre-import'
               b1.use BoxRegister
+              b1.use PrepareClone
+              b1.use PrepareCloneSnapshot
               b1.use Import
               b1.use BoxUnregister
               b1.use SaneDefaults
@@ -348,6 +350,7 @@ module VagrantPlugins
       autoload :Network, File.expand_path('../action/network', __FILE__)
       autoload :Package, File.expand_path('../action/package', __FILE__)
       autoload :PackageConfigFiles, File.expand_path('../action/package_config_files', __FILE__)
+      autoload :PrepareCloneSnapshot, File.expand_path('../action/prepare_clone_snapshot', __FILE__)
       autoload :PrepareForwardedPortCollisionParams, File.expand_path('../action/prepare_forwarded_port_collision_params', __FILE__)
       autoload :PrepareNFSSettings, File.expand_path('../action/prepare_nfs_settings', __FILE__)
       autoload :PrepareNFSValidIds, File.expand_path('../action/prepare_nfs_valid_ids', __FILE__)

--- a/lib/vagrant-parallels/action/box_register.rb
+++ b/lib/vagrant-parallels/action/box_register.rb
@@ -1,0 +1,105 @@
+require 'log4r'
+
+#require 'digest/md5'
+
+module VagrantPlugins
+  module Parallels
+    module Action
+      class BoxRegister
+        def initialize(app, env)
+          @app = app
+          @logger = Log4r::Logger.new('vagrant_parallels::action::box_register')
+        end
+
+        def call(env)
+          # If we don't have a box, nothing to do
+          if !env[:machine].box
+            return @app.call(env)
+          end
+
+          # Do the register while locked so that nobody else register
+          # a box at the same time.
+          lock_key = Digest::MD5.hexdigest(env[:machine].box.name)
+          env[:machine].env.lock(lock_key, retry: true) do
+            register_box(env)
+          end
+
+          # If we got interrupted, then the import could have been
+          # interrupted and its not a big deal. Just return out.
+          return if env[:interrupted]
+
+          # Register completed successfully. Continue the chain
+          @app.call(env)
+        end
+
+        protected
+
+        def box_path(env)
+          pvm = Dir.glob(env[:machine].box.directory.join('*.pvm')).first
+
+          if !pvm
+            raise Errors::BoxImageNotFound, name: env[:machine].box.name
+          end
+
+          pvm
+        end
+
+        def box_id(env, box_path)
+          # Get the box image UUID from XML-based configuration file
+          tpl_config = File.join(box_path, 'config.pvs')
+          xml = Nokogiri::XML(File.open(tpl_config))
+          id = xml.xpath('//ParallelsVirtualMachine/Identification/VmUuid').text
+
+          if !id
+            raise Errors::BoxIDNotFound,
+              name: env[:machine].box.name,
+              config: tpl_config
+          end
+
+          id
+        end
+
+        def register_box(env)
+          box_id_file = env[:machine].box.directory.join('box_id')
+
+          # Read the master ID if we have it in the file.
+          env[:clone_id] = box_id_file.read.chomp if box_id_file.file?
+
+          # If we have the ID and the VM exists already, then we
+          # have nothing to do. Success!
+          if env[:clone_id] && env[:machine].provider.driver.vm_exists?(env[:clone_id])
+            @logger.info(
+              "Box image '#{env[:machine].box.name}' is already registered " +
+                "(id=#{env[:clone_id]}) - skipping register step.")
+            return
+          end
+
+          env[:ui].info I18n.t('vagrant_parallels.actions.vm.box.register',
+                        name: env[:machine].box.name)
+
+          pvm = box_path(env)
+
+          # We need the box ID to be the same for all parallel runs
+          options = ['--preserve-uuid']
+
+          if env[:machine].provider_config.regen_src_uuid \
+            && env[:machine].provider.pd_version_satisfies?('>= 10.1.2')
+            options << '--regenerate-src-uuid'
+          end
+
+          # Register the box VM image
+          env[:machine].provider.driver.register(pvm, options)
+          env[:clone_id] = box_id(env, pvm)
+
+          @logger.info(
+            "Registered box #{env[:machine].box.name} with id #{env[:clone_id]}")
+
+          @logger.debug("Writing box id '#{env[:clone_id]}' to #{box_id_file}")
+          box_id_file.open('w+') do |f|
+            f.write(env[:clone_id])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/action/box_unregister.rb
+++ b/lib/vagrant-parallels/action/box_unregister.rb
@@ -1,0 +1,43 @@
+require 'log4r'
+
+module VagrantPlugins
+  module Parallels
+    module Action
+      class BoxUnregister
+        def initialize(app, env)
+          @app = app
+          @logger = Log4r::Logger.new('vagrant_parallels::action::box_unregister')
+        end
+
+        def call(env)
+          # If we don't have a box, nothing to do
+          if !env[:machine].box
+            return @app.call(env)
+          end
+
+          unregister_box(env)
+
+          # If we got interrupted, then the import could have been
+          # interrupted and its not a big deal. Just return out.
+          return if env[:interrupted]
+
+          # Register completed successfully. Continue the chain
+          @app.call(env)
+        end
+
+        def recover(env)
+          unregister_box(env)
+        end
+
+        private
+
+        def unregister_box(env)
+          if env[:clone_id] && env[:machine].provider.driver.vm_exists?(env[:clone_id])
+            env[:ui].info I18n.t('vagrant_parallels.actions.vm.box.unregister')
+            env[:machine].provider.driver.unregister(env[:clone_id])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -90,10 +90,7 @@ module VagrantPlugins
         end
 
         def clone(env, opts={})
-          # Generate virtual machine name
-          vm_name = "vagrant_vm_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
-
-          @machine.id = @machine.provider.driver.clone_vm(env[:clone_id], vm_name, opts) do |progress|
+          @machine.id = @machine.provider.driver.clone_vm(env[:clone_id], opts) do |progress|
             env[:ui].clear_line
             env[:ui].report_progress(progress, 100, false)
 

--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -99,7 +99,7 @@ module VagrantPlugins
 
         def clone_linked(env)
           opts = {
-            snapshot_id: env[:clone_snapshot],
+            snapshot_id: env[:clone_snapshot_id],
             linked: true
           }
           env[:ui].info I18n.t('vagrant_parallels.actions.vm.clone.linked')

--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -1,5 +1,7 @@
 require 'nokogiri'
 
+require 'digest/md5'
+
 module VagrantPlugins
   module Parallels
     module Action
@@ -10,8 +12,6 @@ module VagrantPlugins
         end
 
         def call(env)
-          @machine = env[:machine]
-
           # Disable requiring password for register and clone actions [GH-67].
           # It is available only since PD 10.
           if env[:machine].provider.pd_version_satisfies?('>= 10')
@@ -20,18 +20,52 @@ module VagrantPlugins
             env[:machine].provider.driver.disable_password_restrictions(acts)
           end
 
-          # Import VM, e.q. clone it from registered template
-          import(env)
+          # Linked clones are supported only for PD 11 and higher
+          if env[:machine].provider_config.linked_clone \
+            && env[:machine].provider.pd_version_satisfies?('>= 11')
+            # Linked clone creation should not be concurrent [GH-206]
+            lock_key = Digest::MD5.hexdigest("#{env[:clone_id]}-linked-clone")
+            env[:machine].env.lock(lock_key, retry: true) do
+              clone_linked(env)
+            end
+          else
+            clone_full(env)
+          end
+
+          # If we got interrupted, then the import could have been
+          # interrupted and its not a big deal. Just return out.
+          return if env[:interrupted]
 
           # Flag as erroneous and return if import failed
-          raise Errors::VMImportFailure if !@machine.id
+          raise Errors::VMCloneFailure if !env[:machine].id
+
+          if env[:machine].provider_config.regen_src_uuid \
+            && env[:machine].provider.pd_version_satisfies?('< 11')
+            @logger.info('Regenerate SourceVmUuid by editing config.pvs file')
+            env[:machine].provider.driver.regenerate_src_uuid
+          end
+
+          # Remove 'Icon\r' file from VM home (bug in PD 11.0.0)
+          if env[:machine].provider.pd_version_satisfies?('= 11.0.0')
+            vm_home = env[:machine].provider.driver.read_settings.fetch('Home')
+            broken_icns = Dir[File.join(vm_home, 'Icon*')]
+            FileUtils.rm(broken_icns, :force => true)
+          end
+
+          # Copy the SSH key from the clone machine if we can
+          if env[:clone_machine]
+            key_path = env[:clone_machine].data_dir.join('private_key')
+            if key_path.file?
+              FileUtils.cp(key_path, env[:machine].data_dir.join('private_key'))
+            end
+          end
 
           # Import completed successfully. Continue the chain
           @app.call(env)
         end
 
         def recover(env)
-          if @machine.state.id != :not_created
+          if env[:machine] && env[:machine].state.id != :not_created
             return if env['vagrant.error'].is_a?(Vagrant::Errors::VagrantError)
             return if env['vagrant_parallels.error'].is_a?(Errors::VagrantParallelsError)
 
@@ -50,53 +84,12 @@ module VagrantPlugins
 
         protected
 
-        def import(env)
-          # Linked clones are supported only for PD 11 and higher
-          if @machine.provider_config.linked_clone \
-            && @machine.provider.pd_version_satisfies?('>= 11')
-
-            env[:ui].info I18n.t('vagrant_parallels.actions.vm.import.importing_linked',
-                                 :name => @machine.box.name)
-            opts = {
-              snapshot_id: snapshot_id(env[:clone_id]),
-              linked: true
-            }
-            # Linked clone creation should not be concurrent [GH-206]
-            begin
-              @machine.env.lock("parallels_linked_clone") do
-                clone(env, opts)
-              end
-            rescue Vagrant::Errors::EnvironmentLockedError
-              sleep 1
-              retry
-            end
-          else
-            env[:ui].info I18n.t('vagrant.actions.vm.import.importing',
-                                 :name => @machine.box.name)
-            clone(env)
-          end
-
-          if @machine.provider_config.regen_src_uuid
-            @logger.info('Regenerate SourceVmUuid')
-            @machine.provider.driver.regenerate_src_uuid
-          end
-
-          # Remove 'Icon\r' file from VM home (bug in PD 11.0.0)
-          if @machine.provider.pd_version_satisfies?('= 11.0.0')
-            vm_home = @machine.provider.driver.read_settings.fetch('Home')
-            broken_icns = Dir[File.join(vm_home, 'Icon*')]
-            FileUtils.rm(broken_icns, :force => true)
-          end
-        end
-
-        def clone(env, opts={})
-          @machine.id = @machine.provider.driver.clone_vm(env[:clone_id], opts) do |progress|
+        def clone_full(env)
+          env[:ui].info I18n.t('vagrant_parallels.actions.vm.clone.full')
+          env[:machine].id = env[:machine].provider.driver.clone_vm(
+            env[:clone_id]) do |progress|
             env[:ui].clear_line
             env[:ui].report_progress(progress, 100, false)
-
-            # # If we got interrupted, then the import could have been interrupted.
-            # Just rise an exception and then 'recover' will be called to cleanup.
-            raise Vagrant::Errors::VagrantInterrupt if env[:interrupted]
           end
 
           # Clear the line one last time since the progress meter doesn't disappear
@@ -104,23 +97,22 @@ module VagrantPlugins
           env[:ui].clear_line
         end
 
-        def snapshot_id(vm_uuid)
-          snap_id = @machine.provider.driver.read_current_snapshot(vm_uuid)
-
-          # If there is no current snapshot, just create the new one.
-          if !snap_id
-            @logger.info('Create a new snapshot')
-            opts = {
-              name: 'vagrant_linked_clone',
-              desc: 'Snapshot to create linked clones for Vagrant'
-            }
-            snap_id = @machine.provider.driver.create_snapshot(vm_uuid, opts)
+        def clone_linked(env)
+          opts = {
+            snapshot_id: env[:clone_snapshot],
+            linked: true
+          }
+          env[:ui].info I18n.t('vagrant_parallels.actions.vm.clone.linked')
+          env[:machine].id = env[:machine].provider.driver.clone_vm(
+            env[:clone_id], opts) do |progress|
+            env[:ui].clear_line
+            env[:ui].report_progress(progress, 100, false)
           end
 
-          @logger.info("User this snapshot ID to create a linked clone: #{snap_id}")
-          snap_id
+          # Clear the line one last time since the progress meter doesn't disappear
+          # immediately.
+          env[:ui].clear_line
         end
-
       end
     end
   end

--- a/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
+++ b/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
@@ -1,0 +1,78 @@
+require 'log4r'
+
+require 'digest/md5'
+
+module VagrantPlugins
+  module Parallels
+    module Action
+      class PrepareCloneSnapshot
+        def initialize(app, env)
+          @app = app
+          @logger = Log4r::Logger.new('vagrant_parallels::action::prepare_clone_snapshot')
+        end
+
+        def call(env)
+          if !env[:clone_id]
+            @logger.info('No source VM for cloning, skip snapshot preparing')
+            return @app.call(env)
+          end
+
+          # If we're not doing a linked clone, snapshots don't matter
+          if !env[:machine].provider_config.linked_clone \
+            || env[:machine].provider.pd_version_satisfies?('< 11')
+            return @app.call(env)
+          end
+
+          # We lock so that we don't snapshot in parallel
+          lock_key = Digest::MD5.hexdigest("#{env[:clone_id]}-snapshot")
+          env[:machine].env.lock(lock_key, retry: true) do
+            prepare_snapshot(env)
+          end
+
+          # Continue
+          @app.call(env)
+        end
+
+        protected
+
+        def prepare_snapshot(env)
+          set_snapshot = env[:machine].provider_config.linked_clone_snapshot
+
+          if set_snapshot
+            # Get the snapshots. We're done if it already exists
+            snapshots = env[:machine].provider.driver.list_snapshots(env[:clone_id])
+
+            if !snapshots.include?(set_snapshot)
+              raise Errors::SnapshotNotFound, snapshot: set_snapshot
+            end
+
+            @logger.info('Specified snapshot already exists, doing nothing')
+            env[:clone_snapshot] = set_snapshot
+            return
+          end
+
+          # Get the current snapshot. If exist - use it for linked clone
+          curr_snapshot = env[:machine].provider.driver.read_current_snapshot(env[:clone_id])
+          if curr_snapshot
+            @logger.info("The source VM already has a snapshot, use it: #{curr_snapshot}")
+            env[:clone_snapshot] = curr_snapshot
+            return
+          end
+
+          opts = {
+            name: 'vagrant_linked_clone',
+            desc: 'Snapshot to create linked clones for Vagrant'
+          }
+          @logger.info('Creating a new snapshot for linked clone')
+          new_snap_id = env[:machine].provider.driver.create_snapshot(
+            env[:clone_id], opts) do |progress|
+              env[:ui].clear_line
+              env[:ui].report_progress(progress, 100, false)
+          end
+
+          env[:clone_snapshot] = new_snap_id
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
+++ b/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
@@ -37,40 +37,25 @@ module VagrantPlugins
 
         def prepare_snapshot(env)
           set_snapshot = env[:machine].provider_config.linked_clone_snapshot
+          env[:clone_snapshot] = set_snapshot || 'vagrant_linked_clone'
 
+          # Get the snapshots. We're done if it already exists
+          snapshots = env[:machine].provider.driver.list_snapshots(env[:clone_id])
+
+          if snapshots.include?(env[:clone_snapshot])
+            env[:clone_snapshot_id] = snapshots[env[:clone_snapshot]]
+            @logger.info('Linked clone snapshot already exists, doing nothing')
+            return
+          end
+
+          # We've specified the snapshot name but it doesn't exist
           if set_snapshot
-            # Get the snapshots. We're done if it already exists
-            snapshots = env[:machine].provider.driver.list_snapshots(env[:clone_id])
-
-            if !snapshots.include?(set_snapshot)
-              raise Errors::SnapshotNotFound, snapshot: set_snapshot
-            end
-
-            @logger.info('Specified snapshot already exists, doing nothing')
-            env[:clone_snapshot] = set_snapshot
-            return
+            raise Errors::SnapshotNotFound, snapshot: set_snapshot
           end
 
-          # Get the current snapshot. If exist - use it for linked clone
-          curr_snapshot = env[:machine].provider.driver.read_current_snapshot(env[:clone_id])
-          if curr_snapshot
-            @logger.info("The source VM already has a snapshot, use it: #{curr_snapshot}")
-            env[:clone_snapshot] = curr_snapshot
-            return
-          end
-
-          opts = {
-            name: 'vagrant_linked_clone',
-            desc: 'Snapshot to create linked clones for Vagrant'
-          }
           @logger.info('Creating a new snapshot for linked clone')
-          new_snap_id = env[:machine].provider.driver.create_snapshot(
-            env[:clone_id], opts) do |progress|
-              env[:ui].clear_line
-              env[:ui].report_progress(progress, 100, false)
-          end
-
-          env[:clone_snapshot] = new_snap_id
+          env[:clone_snapshot_id] = env[:machine].provider.driver.create_snapshot(
+            env[:clone_id], env[:clone_snapshot])
         end
       end
     end

--- a/lib/vagrant-parallels/action/set_name.rb
+++ b/lib/vagrant-parallels/action/set_name.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
           else
             env[:ui].info(I18n.t(
                             'vagrant.actions.vm.set_name.setting_name', name: name))
-            env[:machine].provider.driver.set_name(name)
+            env[:machine].provider.driver.set_name(env[:machine].id, name)
           end
 
           # Create the sentinel

--- a/lib/vagrant-parallels/config.rb
+++ b/lib/vagrant-parallels/config.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
       attr_accessor :functional_psf
       attr_accessor :optimize_power_consumption
       attr_accessor :linked_clone
+      attr_accessor :linked_clone_snapshot
       attr_accessor :name
       attr_reader   :network_adapters
       attr_accessor :regen_src_uuid
@@ -25,6 +26,7 @@ module VagrantPlugins
         @destroy_unused_network_interfaces = UNSET_VALUE
         @functional_psf = UNSET_VALUE
         @linked_clone   = UNSET_VALUE
+        @linked_clone_snapshot = UNSET_VALUE
         @network_adapters  = {}
         @name              = UNSET_VALUE
         @optimize_power_consumption = UNSET_VALUE
@@ -79,6 +81,7 @@ module VagrantPlugins
         end
 
         @linked_clone = false if @linked_clone == UNSET_VALUE
+        @linked_clone_snapshot = nil if @linked_clone_snapshot == UNSET_VALUE
 
         @name = nil if @name == UNSET_VALUE
 

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -204,6 +204,15 @@ module VagrantPlugins
           raise NotImplementedError
         end
 
+        # Lists all snapshots of the specified VM. Returns empty array is
+        # there are no snapshots.
+        #
+        # @param [String] uuid Name or UUID of the target VM.
+        # @return [String]
+        def list_snapshots(uuid)
+          raise NotImplementedError
+        end
+
         # Halts the virtual machine (pulls the plug).
         def halt(force=false)
           args = ['stop', @uuid]

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -55,10 +55,11 @@ module VagrantPlugins
         # Makes a clone of the virtual machine.
         #
         # @param [String] src_name Name or UUID of the source VM or template.
-        # @param [String] dst_name Name of the destination VM.
         # @param [<String => String>] options Options to clone virtual machine.
         # @return [String] UUID of the new VM.
-        def clone_vm(src_name, dst_name, options={})
+        def clone_vm(src_name, options={})
+          dst_name = "vagrant_temp_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
+
           args = ['clone', src_name, '--name', dst_name]
           args << '--template' if options[:template]
           args.concat(['--dst', options[:dst]]) if options[:dst]

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -282,15 +282,6 @@ module VagrantPlugins
           bridged_ifaces
         end
 
-        # Returns current snapshot ID for the specified VM. Returns nil if
-        # the VM doesn't have any snapshot.
-        #
-        # @param [String] uuid Name or UUID of the target VM.
-        # @return [String]
-        def read_current_snapshot(uuid)
-          raise NotImplementedError
-        end
-
         def read_forwarded_ports(global=false)
           raise NotImplementedError
         end

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -491,8 +491,9 @@ module VagrantPlugins
         # Registers the virtual machine
         #
         # @param [String] pvm_file Path to the machine image (*.pvm)
-        def register(pvm_file)
-          args = [@prlctl_path, 'register', pvm_file]
+        # @param [Array<String>] opts List of options for "prlctl register"
+        def register(pvm_file, opts=[])
+          args = [@prlctl_path, 'register', pvm_file, *opts]
 
           3.times do
             result = raw(*args)

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -522,9 +522,10 @@ module VagrantPlugins
 
         # Sets the name of the virtual machine.
         #
-        # @param [String] name New VM name.
-        def set_name(name)
-          execute_prlctl('set', @uuid, '--name', name)
+        # @param [String] uuid VM name or UUID
+        # @param [String] new_name New VM name
+        def set_name(uuid, new_name)
+          execute_prlctl('set', uuid, '--name', new_name)
         end
 
         # Sets Power Consumption method.

--- a/lib/vagrant-parallels/driver/meta.rb
+++ b/lib/vagrant-parallels/driver/meta.rb
@@ -77,6 +77,7 @@ module VagrantPlugins
                        :forward_ports,
                        :halt,
                        :clone_vm,
+                       :list_snapshots,
                        :read_bridged_interfaces,
                        :read_current_snapshot,
                        :read_forwarded_ports,

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -15,23 +15,6 @@ module VagrantPlugins
           @logger = Log4r::Logger.new('vagrant_parallels::driver::pd_11')
         end
 
-        def create_snapshot(uuid, options)
-          args = ['snapshot', uuid]
-          args.concat(['--name', options[:name]]) if options[:name]
-          args.concat(['--description', options[:desc]]) if options[:desc]
-
-          stdout = execute_prlctl(*args)
-          if stdout =~ /\{([\w-]+)\}/
-            return $1
-          end
-
-          raise Errors::SnapshotIdNotDetected, stdout: stdout
-        end
-
-        def list_snapshots(uuid)
-          execute_prlctl('snapshot-list', uuid).scan(/\{([\w-]+)\}$/).flatten
-        end
-
         def read_current_snapshot(uuid)
           if execute_prlctl('snapshot-list', uuid) =~ /\*\{([\w-]+)\}/
             return $1

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -28,6 +28,10 @@ module VagrantPlugins
           raise Errors::SnapshotIdNotDetected, stdout: stdout
         end
 
+        def list_snapshots(uuid)
+          execute_prlctl('snapshot-list', uuid).scan(/\{([\w-]+)\}$/).flatten
+        end
+
         def read_current_snapshot(uuid)
           if execute_prlctl('snapshot-list', uuid) =~ /\*\{([\w-]+)\}/
             return $1

--- a/lib/vagrant-parallels/driver/pd_11.rb
+++ b/lib/vagrant-parallels/driver/pd_11.rb
@@ -14,14 +14,6 @@ module VagrantPlugins
 
           @logger = Log4r::Logger.new('vagrant_parallels::driver::pd_11')
         end
-
-        def read_current_snapshot(uuid)
-          if execute_prlctl('snapshot-list', uuid) =~ /\*\{([\w-]+)\}/
-            return $1
-          end
-
-          nil
-        end
       end
     end
   end

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -79,8 +79,12 @@ module VagrantPlugins
         error_key(:snapshot_id_not_detected)
       end
 
-      class VMImportFailure < VagrantParallelsError
-        error_key(:vm_import_failure)
+      class SnapshotNotFound < VagrantParallelsError
+        error_key(:snapshot_not_found)
+      end
+
+      class VMCloneFailure < VagrantParallelsError
+        error_key(:vm_clone_failure)
       end
 
       class VMNameExists < VagrantParallelsError

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -7,6 +7,14 @@ module VagrantPlugins
         error_namespace('vagrant_parallels.errors')
       end
 
+      class BoxImageNotFound < VagrantParallelsError
+        error_key(:box_image_not_found)
+      end
+
+      class BoxIDNotFound < VagrantParallelsError
+        error_key(:box_id_not_found)
+      end
+
       class DhcpLeasesNotAccessible < VagrantParallelsError
         error_key(:dhcp_leases_file_not_accessible)
       end
@@ -49,10 +57,6 @@ module VagrantPlugins
 
       class ParallelsToolsIsoNotFound < VagrantParallelsError
         error_key(:parallels_tools_iso_not_found)
-      end
-
-      class ParallelsTplNameNotFound < VagrantParallelsError
-        error_key(:parallels_tpl_name_not_found)
       end
 
       class ParallelsVMOptionNotFound < VagrantParallelsError

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -6,8 +6,8 @@ end
 
 # This is a sanity check to make sure no one is attempting to install
 # this into an early Vagrant version.
-if Gem::Version.new(Vagrant::VERSION).release < Gem::Version.new('1.5.0')
-  raise 'The installed version of Vagrant Parallels plugin is only compatible with Vagrant 1.5+'
+if Gem::Version.new(Vagrant::VERSION).release < Gem::Version.new('1.8.0')
+  raise 'The installed version of Vagrant Parallels plugin is only compatible with Vagrant 1.8+'
 end
 
 module VagrantPlugins

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -7,6 +7,18 @@ en:
 # Translations for exception classes
 #-------------------------------------------------------------------------------
     errors:
+      box_id_not_found: |-
+        Parallels provider couldn't fetch the box image ID. This is usually because
+        the "config.pvs" file is corrupted or doesn't exist. Please remove the box,
+        re-add it, and try again.
+
+        Box: "%{name}"
+        Box VM config: "%{config}"
+
+      box_image_not_found: |-
+        Parallels VM image (*.pvm) could not be found in the directory of
+        '%{name}' box. This is usually because the image has been removed manually.
+        Please remove the box, re-add it, and try again.
       dhcp_leases_file_not_accessible: |-
         Parallels DHCP leases file is not accessible. The Parallels provider
         uses it to detect an IP address of virtual machine. This file must be
@@ -67,12 +79,6 @@ en:
         reinstall Parallels Desktop.
 
         Expected ISO path: "%{iso_path}"
-      parallels_tpl_name_not_found: |-
-        The VM import failed! Template name not found. Please verify that
-        the box you're using is not corrupted and try again.
-
-        Template config path: "%{config_path}"
-
       parallels_vm_option_not_found: |-
         Could not find a required option of Parallels Desktop virtual machine:
           %{vm_option}
@@ -170,6 +176,9 @@ en:
 #-------------------------------------------------------------------------------
     actions:
       vm:
+        box:
+          register: Registering VM template from the base box '%{name}'...
+          unregister: Unregistering VM template...
         handle_guest_tools:
           cant_install: |-
             Vagrant doesn't support installing Parallels Tools for the guest OS

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -101,17 +101,22 @@ en:
         Desktop for Mac. Please, be aware while choosing the edition to upgrade to.
       snapshot_id_not_detected: |-
         ID of the newly created shapshod could not be detected. This is an
-        internal error that users should never see. Please report a bug.
+        internal error that users should never see. Please report a bug to
+        Parallels provider.
 
         stdout: %{stdout}
+      snapshot_not_found: |-
+        The 'linked_clone_snapshot' specified could not be found. Please double
+        check and try again.
+
+         Snapshot ID: %{snapshot}
       shared_adapter_not_found: |-
         Shared network adapter was not found in your virtual machine configuration.
         It is required to communicate with VM and forward ports. Please check
         network configuration in your Vagrantfile.
-      vm_import_failure: |-
-        The VM import failed! Please verify that the box you're using is not
+      vm_clone_failure: |-
+        The VM cloning failed! Please ensure that the box you're using is not
         corrupted and try again.
-
       vm_name_exists: |-
         Parallels Desktop virtual machine with the name '%{name}' already exists.
         Please use another name or delete the machine with the existing
@@ -179,6 +184,9 @@ en:
         box:
           register: Registering VM template from the base box '%{name}'...
           unregister: Unregistering VM template...
+        clone:
+          full: Cloning new virtual machine...
+          linked: Creating new virtual machine as a linked clone...
         handle_guest_tools:
           cant_install: |-
             Vagrant doesn't support installing Parallels Tools for the guest OS
@@ -200,14 +208,12 @@ en:
             Parallels Tools installed on this VM are outdated! In most cases
             this is fine but in rare cases it can cause things such as shared
             folders to not work properly. If you see shared folder errors,
-            please update Parallels Tools within the virtual machine and 
+            please update Parallels Tools within the virtual machine and
             reload your VM.
         export:
           compacting: Compacting exported HDDs...
         forward_ports:
           forwarding_entry: |-
             %{guest_port} => %{host_port}
-        import:
-          importing_linked: Importing base box '%{name}' as a linked clone...
         sane_defaults:
           setting: Setting the default configuration for VM...

--- a/test/unit/support/shared/pd_driver_examples.rb
+++ b/test/unit/support/shared/pd_driver_examples.rb
@@ -118,21 +118,19 @@ shared_examples 'parallels desktop driver' do |options|
   describe 'clone_vm' do
     it 'clones VM to the new one' do
       subprocess.should_receive(:execute).
-        with('prlctl', 'clone', tpl_uuid, '--name', vm_name,
+        with('prlctl', 'clone', tpl_uuid, '--name', an_instance_of(String),
              an_instance_of(Hash)).
         and_return(subprocess_result(exit_code: 0))
-      subject.clone_vm(tpl_uuid, vm_name).should == uuid
+      subject.clone_vm(tpl_uuid)
     end
 
     it 'clones VM to template' do
       subprocess.should_receive(:execute).
-        with('prlctl', 'clone', uuid, '--name', tpl_name,
+        with('prlctl', 'clone', uuid, '--name', an_instance_of(String),
              '--template', '--dst', an_instance_of(String),
              an_instance_of(Hash)).
         and_return(subprocess_result(exit_code: 0))
-      subject.clone_vm(uuid, tpl_name,
-                       {dst: '/path/to/template', template: true}).
-        should == tpl_uuid
+      subject.clone_vm(uuid, {dst: '/path/to/template', template: true})
     end
   end
 

--- a/test/unit/support/shared/pd_driver_examples.rb
+++ b/test/unit/support/shared/pd_driver_examples.rb
@@ -265,7 +265,7 @@ shared_examples 'parallels desktop driver' do |options|
              an_instance_of(Hash)).
         and_return(subprocess_result(exit_code: 0))
 
-      subject.set_name('new_vm_name')
+      subject.set_name(uuid, 'new_vm_name')
     end
   end
 


### PR DESCRIPTION
There is a pretty big PR mostly related to the `Import` action refactoring and adding the support of "Clone another Vagrant environment" (which is an experimental feature and is not documented)

### Details:
* `Import` action split: box register/unregister logic is moved to standalone actions `BoxRegister` and `BoxUnregister`
* Linked clone management moved to the standalone action `PrepareCloneSnapshot`
* Add support of core feature "Clone another Vagrant environment" (https://github.com/mitchellh/vagrant/pull/6378). It is hidden, but in few words it allows to create a new Vagrant VM not only from the box-shipped template, but by cloning an existing Vagrant VM as well. 
In case of Parallels provider both of full and linked clones are supported.
* Supported Vagrant version is restricted to 1.8+ , because we use new core actions & config options which will be available only in upcoming Vagrant 1.8.0. That's why this PR is sent to custom branch, not to master.

cc: @racktear , @Kasen