### PR TITLE
Fix port forwarding collisions in parallel run of multi-machine env

### DIFF
--- a/lib/vagrant-parallels/action/forward_ports.rb
+++ b/lib/vagrant-parallels/action/forward_ports.rb
@@ -23,6 +23,9 @@ module VagrantPlugins
           # Get the ports we're forwarding
           env[:forwarded_ports] ||= compile_forwarded_ports(env[:machine].config)
 
+          # Exit if there are no ports to forward
+          return @app.call(env) if env[:forwarded_ports].empty?
+
           # Acquire both of class- and process-level locks so that we don't
           # forward ports simultaneousely with someone else.
           @@lock.synchronize do
@@ -41,6 +44,8 @@ module VagrantPlugins
         end
 
         def forward_ports
+          all_rules = @env[:machine].provider.driver.read_forwarded_ports(true)
+          names_in_use = all_rules.collect { |r| r[:rule_name] }
           ports = []
 
           @env[:forwarded_ports].each do |fp|
@@ -56,11 +61,22 @@ module VagrantPlugins
             @env[:ui].detail(I18n.t('vagrant_parallels.actions.vm.forward_ports.forwarding_entry',
                                     message_attributes))
 
+            # In Parallels Desktop the scope port forwarding rules is global,
+            # so we have to keep their names unique.
+            unique_id = fp.id
+            # Append random suffix to get the unique rule name
+            while names_in_use.include?(unique_id)
+              suffix = (0...4).map { ('a'..'z').to_a[rand(26)] }.join
+              unique_id = "#{fp.id}_#{suffix}"
+            end
+            # Mark this rule name as in use
+            names_in_use << unique_id
+
             # Add the options to the ports array to send to the driver later
             ports << {
               guestport: fp.guest_port,
               hostport:  fp.host_port,
-              name:      get_unique_name(fp.id),
+              name:      unique_id,
               protocol:  fp.protocol
             }
           end
@@ -69,21 +85,6 @@ module VagrantPlugins
             # We only need to forward ports if there are any to forward
             @env[:machine].provider.driver.forward_ports(ports)
           end
-        end
-
-        private
-
-        def get_unique_name(id)
-          all_rules = @env[:machine].provider.driver.read_forwarded_ports(true)
-          names_in_use = all_rules.collect { |r| r[:rule_name] }
-
-          # Append random suffix to get unique rule name
-          while names_in_use.include?(id)
-            suffix = (0...4).map { ('a'..'z').to_a[rand(26)] }.join
-            id = "#{id}_#{suffix}"
-          end
-
-          id
         end
       end
     end


### PR DESCRIPTION
While doing a parallel run of multi-machine environment the race condition could happen:

```console
...
There was an error while command execution. The command and stderr is shown below.

Command: ["/usr/local/bin/prlsrvctl", "net", "set", "Shared", "--nat-tcp-add", "winrm,2200,8977eda8-08ae-46d3-8923-469d8091ad69,5985", "--nat-tcp-add", "winrm-ssl,2201,8977eda8-08ae-46d3-8923-469d8091ad69,5986"]

Stderr: The rule with 'winrm' name already exists!
```

This PR fixes that by adding adds both class- and process-level locks, so port forwarding will be proceeded subsequently.

Also, I've improved the `forward_ports ` helper by decreasing the number of driver method calls. Now it should work a little bit faster.

cc: @Gray-Wind @racktear @Kasen
