### PR TITLE
Support for "Snapshot" feature (Vagrant 1.8+)

### DIFF
--- a/lib/vagrant-parallels/action/box_register.rb
+++ b/lib/vagrant-parallels/action/box_register.rb
@@ -1,7 +1,5 @@
 require 'log4r'
 
-#require 'digest/md5'
-
 module VagrantPlugins
   module Parallels
     module Action

--- a/lib/vagrant-parallels/action/snapshot_delete.rb
+++ b/lib/vagrant-parallels/action/snapshot_delete.rb
@@ -1,0 +1,25 @@
+module VagrantPlugins
+  module Parallels
+    module Action
+      class SnapshotDelete
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          snapshots = env[:machine].provider.driver.list_snapshots(env[:machine].id)
+          snapshot_id = snapshots[env[:snapshot_name]]
+
+          env[:ui].info I18n.t('vagrant.actions.vm.snapshot.deleting',
+                               name: env[:snapshot_name])
+          env[:machine].provider.driver.delete_snapshot(
+            env[:machine].id, snapshot_id)
+
+          env[:ui].success I18n.t('vagrant.actions.vm.snapshot.deleted',
+                                  name: env[:snapshot_name])
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/action/snapshot_restore.rb
+++ b/lib/vagrant-parallels/action/snapshot_restore.rb
@@ -1,0 +1,23 @@
+module VagrantPlugins
+  module Parallels
+    module Action
+      class SnapshotRestore
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          snapshots = env[:machine].provider.driver.list_snapshots(env[:machine].id)
+          snapshot_id = snapshots[env[:snapshot_name]]
+
+          env[:ui].info I18n.t('vagrant.actions.vm.snapshot.restoring',
+                               name: env[:snapshot_name])
+          env[:machine].provider.driver.restore_snapshot(
+            env[:machine].id, snapshot_id)
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/action/snapshot_save.rb
+++ b/lib/vagrant-parallels/action/snapshot_save.rb
@@ -1,0 +1,23 @@
+module VagrantPlugins
+  module Parallels
+    module Action
+      class SnapshotSave
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info I18n.t('vagrant.actions.vm.snapshot.saving',
+                               name: env[:snapshot_name])
+          env[:machine].provider.driver.create_snapshot(
+            env[:machine].id, env[:snapshot_name])
+
+          env[:ui].success I18n.t('vagrant.actions.vm.snapshot.saved',
+                                  name: env[:snapshot_name])
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/cap/snapshot_list.rb
+++ b/lib/vagrant-parallels/cap/snapshot_list.rb
@@ -1,0 +1,14 @@
+module VagrantPlugins
+  module Parallels
+    module Cap
+      module SnapshotList
+        # Returns a list of the snapshots that are taken on this machine.
+        #
+        # @return [Array<String>] Snapshot Name
+        def self.snapshot_list(machine)
+          machine.provider.driver.list_snapshots(machine.id).keys
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -154,6 +154,14 @@ module VagrantPlugins
           end
         end
 
+        # Deletes the specified snapshot
+        #
+        # @param [String] uuid Name or UUID of the target VM
+        # @param [String] snapshot_id Snapshot ID
+        def delete_snapshot(uuid, snapshot_id)
+          execute_prlctl('snapshot-delete', uuid, '--id', snapshot_id)
+        end
+
         # Deletes any host only networks that aren't being used for anything.
         def delete_unused_host_only_networks
           raise NotImplementedError
@@ -538,6 +546,14 @@ module VagrantPlugins
           # failure, do a standard execute now. This will raise an
           # exception if it fails again.
           execute(*args)
+        end
+
+        # Switches the VM state to the specified snapshot
+        #
+        # @param [String] uuid Name or UUID of the target VM
+        # @param [String] snapshot_id Snapshot ID
+        def restore_snapshot(uuid, snapshot_id)
+          execute_prlctl('snapshot-switch', uuid, '-i', snapshot_id)
         end
 
         # Resumes the virtual machine.

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -78,6 +78,11 @@ module VagrantPlugins
         Cap::NicMacAddresses
       end
 
+      provider_capability(:parallels, :snapshot_list) do
+        require_relative 'cap/snapshot_list'
+        Cap::SnapshotList
+      end
+
       synced_folder(:parallels) do
         require_relative 'synced_folder'
         SyncedFolder


### PR DESCRIPTION
In Vagrant 1.8 there will be new feature added: https://github.com/mitchellh/vagrant/pull/6374
In few words, it allows to manage VM snapshots with command `vagrant snapshot`

BTW, it was implemented two years ago by ["sahara"](https://github.com/jedi4ever/sahara) plugin ;-)

So, we should definitely support this feature. And thankfully to GH-224, it was not so hard to implement.

@Gray-Wind @Kasen @racktear 