### PR TITLE
support for boxes that include an ISO file.

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -75,6 +75,15 @@ module VagrantPlugins
               yield $1.to_i if block_given?
             end
           end
+
+          # copy any ISO files from the template to the clone. unfortunately
+          # this is not done by prlctl clone
+          clone_home = read_settings(dst_name).fetch('Home')
+          iso_files = Dir[File.join(read_settings(src_name).fetch('Home'), '*.iso')]
+          iso_files.each do |file|
+              FileUtils.cp(file, clone_home)
+          end
+
           read_vms[dst_name]
         end
 


### PR DESCRIPTION
Vagrant supports boxes that include ISO files. This enables scenarios where you want to distribute a box with a mounted CDROM for example. Unfortunately the vagrant parallels provider does not support due to the way it relies on prlctl clone to copy the contents from the box to the vm.

The following is a targeted fix for this. It copies any .iso files in the box to the cloned VM. I tested with boxes that bundle ISO files and they boot up with the CDROM mounted as expected.