### PR TITLE
Update documentation site

### DIFF
--- a/website/docs/Gemfile
+++ b/website/docs/Gemfile
@@ -6,8 +6,3 @@ gem 'middleman-deploy', '~> 1.0'
 gem 'rack-contrib', '~> 1.1.0'
 gem 'redcarpet', '~> 2.2.2'
 gem 'therubyracer', '~> 0.12.0'
-gem 'thin', '~> 1.5.0'
-
-group :development do
-  gem 'highline', '~> 1.6.15'
-end

--- a/website/docs/Procfile
+++ b/website/docs/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec thin start -p $PORT

--- a/website/docs/source/docs/boxes/index.html.md
+++ b/website/docs/source/docs/boxes/index.html.md
@@ -8,17 +8,17 @@ sidebar_current: "boxes"
 As with [every provider](http://docs.vagrantup.com/v2/providers/basic_usage.html), 
 the Parallels provider has a custom box format.
 
-The easiest way to use a box is to add a box from the [Atlas website](https://atlas.hashicorp.com/parallels). 
+The actual list of official boxes provided by Parallels is available 
+[on wiki page](https://github.com/Parallels/vagrant-parallels/wiki/Available-Vagrant-Boxes). 
+
+All boxes from Parallels could be found on the ["parallels" page on Atlas](https://atlas.hashicorp.com/parallels). 
 You can also add and share your own customized boxes there. Read more on the 
 [Atlas Help](https://atlas.hashicorp.com/help) page. 
 
 ## Discovering boxes
 
-The easiest way to find boxes is to look on the public Vagrant box catalog for a
-box matching your use case: [all boxes with the Parallels provider support](https://atlas.hashicorp.com/boxes/search?provider=parallels)
-
-Official boxes compatible with Parallels provider are available on the
-[parallels account page](https://atlas.hashicorp.com/parallels)
+You can also look up all community Vagrant boxes for "parallels" provider 
+and find the box matching your use case: [https://atlas.hashicorp.com/boxes/search?provider=parallels](https://atlas.hashicorp.com/boxes/search?provider=parallels)
 
 Adding a box from the catalog is very easy:
 
@@ -27,7 +27,7 @@ $ vagrant box add parallels/ubuntu-14.04
 ...
 ```
 
-You can also quickly initialize a Vagrant environment with command
+You can also quickly initialize a Vagrant environment with command:
 
 ```
 $ vagrant init parallels/ubuntu-14.04

--- a/website/docs/source/docs/boxes/packer.html.md
+++ b/website/docs/source/docs/boxes/packer.html.md
@@ -20,8 +20,14 @@ Read the installation instruction here: [Install Packer](https://packer.io/docs/
 
 Packer requires the 'prlsdkapi' Python module from the Parallels Virtualization
 SDK to interact with Parallels Desktop and virtual machines. To use Parallels 
-builders for Packer you need to download and install this SDK: 
+builders for Packer you need to download and install this SDK package: 
 [The Parallels Virtualization SDK for Mac](http://www.parallels.com/download/pvsdk/)
+
+You can also install it with [Homebrew](brew.sh) package manager:
+
+```
+$ brew cask install parallels-virtualization-sdk
+```
 
 ## Packer Templates
 Packer is shipped with `parallels-iso` builder, which can be used to create 

--- a/website/docs/source/docs/boxes/veewee.html.md
+++ b/website/docs/source/docs/boxes/veewee.html.md
@@ -22,8 +22,14 @@ instructions.
 
 Veewee requires the 'prlsdkapi' Python module from the Parallels Virtualization
 SDK to interact with Parallels Desktop and virtual machines. To use Veewee with
-the Parallels provider you need to download and install this SDK: 
+the Parallels provider you need to download and install this SDK package: 
 [The Parallels Virtualization SDK for Mac](http://www.parallels.com/download/pvsdk/)
+
+You can also install it with [Homebrew](brew.sh) package manager:
+
+```
+$ brew cask install parallels-virtualization-sdk
+```
 
 ## Preparing a definition
 

--- a/website/docs/source/docs/configuration.html.md
+++ b/website/docs/source/docs/configuration.html.md
@@ -43,14 +43,14 @@ config.vm.provider "parallels" do |prl|
 end
 ```
 
-Difference between linked and regular clones:
+Difference between linked and full clones:
 
-- Linked clone creation is extremely faster than the regular cloning, because 
+- Linked clone creation is extremely faster than the full cloning, because 
 there is no image copying process.
-- Linked clone require much less disk space, because its hard disk image is less 
-than 1Mb initially (it is bound to the parent's snapshot).
-- Regular clone is a full image copy, which is independent from the box. 
-The linked clone is bound to the specific snapshot of the box image. It means 
+- Linked clone requires much less disk space, because initially its hard disk 
+image is less than 1Mb (it is bound to the parent's snapshot).
+- Full clone is a full image copy, which is independent from the box. 
+Linked clones are bound to the specific snapshot of the box image. It means 
 that box deletion will cause all its linked clones being corrupted. Then please,
 delete your boxes carefully!
 

--- a/website/docs/source/docs/configuration.html.md
+++ b/website/docs/source/docs/configuration.html.md
@@ -65,7 +65,7 @@ delete your boxes carefully!
 
 Parallels Tools is a set of Parallels utilities that ensures a high level of
 integration between the host and the guest operating systems (read more:
-[Parallels Tools Overview](http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Desktop%20User's%20Guide/32789.htm)).
+[Parallels Tools Overview](http://download.parallels.com/desktop/v11/docs/en_US/Parallels%20Desktop%20User's%20Guide/32789.htm)).
 
 By default the Parallels provider checks the status of Parallels Tools after
 booting the machine. If they are outdated or newer, a warning message will be
@@ -128,5 +128,5 @@ end
 ```
 
 
-You can read the [Reference Guide](http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Command%20Line%20Reference%20Guide.pdf)
+You can read the [Command-Line Reference](http://download.parallels.com/desktop/v11/docs/en_US/Parallels%20Desktop%20Pro%20Edition%20Command-Line%20Reference.pdf)
 for the complete information about the prlctl command and its options.

--- a/website/docs/source/docs/getting-started.html.md
+++ b/website/docs/source/docs/getting-started.html.md
@@ -25,7 +25,7 @@ Create a new directory and init the new Vagrant project in it:
 ```
 $ mkdir new_vagrant_project
 $ cd new_vagrant_project
-$ vagrant init parallels/centos-6.6
+$ vagrant init parallels/ubuntu-14.04
 $ vagrant up --provider=parallels
 ```
 

--- a/website/docs/source/docs/share.html.md
+++ b/website/docs/source/docs/share.html.md
@@ -24,5 +24,5 @@ instant SSH access to your Vagrant environment by anyone by running `vagrant
 connect --ssh` on the remote side. This is useful for pair programming,
 debugging ops problems, etc.
 
-Vagrant Share requires an account with [Vagrant Cloud](https://vagrantcloud.com/)
+Vagrant Share requires an account with [HashiCorp's Atlas](https://atlas.hashicorp.com/)
 to be used.

--- a/website/docs/source/docs/usage.html.md
+++ b/website/docs/source/docs/usage.html.md
@@ -14,7 +14,7 @@ provider shipped with Vagrant. In most cases you will not have to specify the
 provider name, just "vagrant up" will be enough: 
 
 ```
-$ vagrant init parallels/centos-6.6
+$ vagrant init parallels/ubuntu-14.04
 $ vagrant up
 ```
 


### PR DESCRIPTION
* Removed Procfile and unused gems from Gemfile
* Change example box name to "ubuntu-14.04"
* Add "brew" way for installing Parallels Virtualization SDK
* Update "boxes" index page
* Change name and link "VagrantCloud" to "Atlas"
* Update "linked clone" feature description
* Update URL for "Parallels Tools Overview" and "Command-Line Reference"

cc: @racktear 