### PR TITLE
Networking: handle a list of bridged NICs

### DIFF
--- a/lib/vagrant-parallels/action/network.rb
+++ b/lib/vagrant-parallels/action/network.rb
@@ -161,12 +161,16 @@ module VagrantPlugins
             @logger.debug("Bridge was directly specified in config, searching for: #{config[:bridge]}")
 
             # Search for a matching bridged interface
-            bridgedifs.each do |interface|
-              if interface[:name].downcase == config[:bridge].downcase
-                @logger.debug('Specific bridge found as configured in the Vagrantfile. Using it.')
-                chosen_bridge = interface[:name]
-                break
+            Array(config[:bridge]).each do |bridge|
+              bridge = bridge.downcase if bridge.respond_to?(:downcase)
+              bridgedifs.each do |interface|
+                if bridge === interface[:name].downcase
+                  @logger.debug('Specific bridge found as configured in the Vagrantfile. Using it.')
+                  chosen_bridge = interface[:name]
+                  break
+                end
               end
+              break if chosen_bridge
             end
 
             # If one wasn't found, then we notify the user here.

--- a/website/docs/source/docs/networking/public_network.html.md
+++ b/website/docs/source/docs/networking/public_network.html.md
@@ -39,10 +39,19 @@ definition.
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.network "public_network", bridge: 'en1'
+  config.vm.network "public_network", bridge: "en1"
 end
 ```
 
-The string identifying the desired interface must exactly match the name of an
-available interface. If it can't be found, Vagrant will ask you to pick
-from a list of available network interfaces.
+The string identifying the desired interface must match either the name or 
+identifier of an available interface. If it can't be found, Vagrant will ask you 
+to pick from a list of available network interfaces.
+
+It is also possible to specify a list of adapters to bridge against:
+
+```ruby
+config.vm.network "public_network", bridge: ["en1", "en6"]
+```
+
+In this example, the first network adapter that exists and can successfully be
+bridge will be used.


### PR DESCRIPTION
This PR ports the similar one from the upstream: https://github.com/mitchellh/vagrant/pull/5691

This change allows you to specify multiple network interfaces to bridge to in the order you want them tried, picking the first match:

```
config.vm.network "public_network", bridge: ["en1", "en6"]
```

cc: @racktear 