### PR TITLE
Pass "--regenerate-src-uuid" option to the command "clone"

### DIFF
--- a/lib/vagrant-parallels/action/box_register.rb
+++ b/lib/vagrant-parallels/action/box_register.rb
@@ -84,11 +84,6 @@ module VagrantPlugins
           # We need the box ID to be the same for all parallel runs
           options = ['--preserve-uuid']
 
-          if env[:machine].provider_config.regen_src_uuid \
-            && env[:machine].provider.pd_version_satisfies?('>= 10.1.2')
-            options << '--regenerate-src-uuid'
-          end
-
           # Register the box VM image
           env[:machine].provider.driver.register(pvm, options)
           env[:clone_id] = box_id(env, pvm)

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -67,6 +67,9 @@ module VagrantPlugins
           args << '--linked' if options[:linked]
           args.concat(['--id', options[:snapshot_id]]) if options[:snapshot_id]
 
+          # Regenerate SourceVmUuid of the cloned VM
+          args << '--regenerate-src-uuid' if options[:regenerate_src_uuid]
+
           execute_prlctl(*args) do |_, data|
             lines = data.split('\r')
             # The progress of the clone will be in the last line. Do a greedy


### PR DESCRIPTION
Fixes GH-239

In parallel env `prlctl register` is called once for all machines, and SourceVmUuid is not unique.
So, we have to pass this option to `prlctl clone` command instead.
This option is supported for Parallels Desktop >= 10.1.2.
For earlier versions we still have to regenerate SourceVmUuid by editing `config.pvs`