### PR TITLE
Boxes: Use temporary lock file to prevent early unregister

### DIFF
--- a/lib/vagrant-parallels/action/box_register.rb
+++ b/lib/vagrant-parallels/action/box_register.rb
@@ -77,6 +77,8 @@ module VagrantPlugins
             num = file.gets.to_i
             file.rewind
             file.puts num.next
+            file.fsync
+            file.flush
           end
         end
 

--- a/lib/vagrant-parallels/action/box_register.rb
+++ b/lib/vagrant-parallels/action/box_register.rb
@@ -58,7 +58,7 @@ module VagrantPlugins
               config: tpl_config
           end
 
-          id
+          id.delete('{}')
         end
 
         def register_box(env)

--- a/lib/vagrant-parallels/action/box_unregister.rb
+++ b/lib/vagrant-parallels/action/box_unregister.rb
@@ -39,6 +39,8 @@ module VagrantPlugins
             num = file.gets.to_i
             file.rewind
             file.puts(num - 1)
+            file.fsync
+            file.flush
           end
 
           # Delete the lease file if we are the last who need this box.

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -529,25 +529,7 @@ module VagrantPlugins
         # @param [String] pvm_file Path to the machine image (*.pvm)
         # @param [Array<String>] opts List of options for "prlctl register"
         def register(pvm_file, opts=[])
-          args = [@prlctl_path, 'register', pvm_file, *opts]
-
-          3.times do
-            result = raw(*args)
-            # Exit if everything is OK
-            return if result.exit_code == 0
-
-            # It may occur in the race condition with other Vagrant processes.
-            # It is OK, just exit.
-            return if result.stderr.include?('is already registered.')
-
-            # Sleep a bit though to give Parallels Desktop time to fix itself
-            sleep 2
-          end
-
-          # If we reach this point, it means that we consistently got the
-          # failure, do a standard execute now. This will raise an
-          # exception if it fails again.
-          execute(*args)
+          execute_prlctl('register', pvm_file, *opts)
         end
 
         # Switches the VM state to the specified snapshot
@@ -622,25 +604,7 @@ module VagrantPlugins
         # Virtual machine will be removed from the VM list, but its image will
         # not be deleted from the disk. So, it can be registered again.
         def unregister(uuid)
-          args = [@prlctl_path, 'unregister', uuid]
-          3.times do
-            result = raw(*args)
-            # Exit if everything is OK
-            return if result.exit_code == 0
-
-            # It may occur in the race condition with other Vagrant processes.
-            # Both are OK, just exit.
-            return if result.stderr.include?('is not registered')
-            return if result.stderr.include?('is being cloned')
-
-            # Sleep a bit though to give Parallels Desktop time to fix itself
-            sleep 2
-          end
-
-          # If we reach this point, it means that we consistently got the
-          # failure, do a standard execute now. This will raise an
-          # exception if it fails again.
-          execute(*args)
+          execute_prlctl('unregister', uuid)
         end
 
         # Unshare folders.


### PR DESCRIPTION
Fixes GH-243

In parallel run of multi-machine environment the same box image could be cloning
simultaneously by more then one envs. But the box should be unregister exactly by the last env.

To prevent a race condition here, we add a temporary lease file with a counter.
It is incremented for incoming envs (new clones) and decremented right after the cloning.
The last env removes the lock file and unregisters the box.

cc: @racktear @Gray-Wind @Kasen