### PR TITLE
Define provider actions for snapshot management

### DIFF
--- a/lib/vagrant-parallels/action.rb
+++ b/lib/vagrant-parallels/action.rb
@@ -179,6 +179,50 @@ module VagrantPlugins
         end
       end
 
+      def self.action_snapshot_delete
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Call, IsState, :not_created do |env1, b1|
+            if env1[:result]
+              b1.use Message, I18n.t('vagrant.commands.common.vm_not_created')
+            else
+              b1.use SnapshotDelete
+            end
+          end
+        end
+      end
+
+      # This is the action that is primarily responsible for saving a snapshot
+      def self.action_snapshot_restore
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Call, IsState, :not_created do |env1, b1|
+            if env1[:result]
+              b1.use Message, I18n.t('vagrant.commands.common.vm_not_created')
+              next
+            end
+
+            b1.use SnapshotRestore
+            b1.use Call, IsEnvSet, :snapshot_delete do |env2, b2|
+              if env2[:result]
+                b2.use action_snapshot_delete
+              end
+            end
+          end
+        end
+      end
+
+      # This is the action that is primarily responsible for saving a snapshot
+      def self.action_snapshot_save
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Call, IsState, :not_created do |env1, b1|
+            if env1[:result]
+              b1.use Message, I18n.t('vagrant.commands.common.vm_not_created')
+            else
+              b1.use SnapshotSave
+            end
+          end
+        end
+      end
+
       # This is the action that will exec into an SSH shell.
       def self.action_ssh
         Vagrant::Action::Builder.new.tap do |b|
@@ -365,6 +409,9 @@ module VagrantPlugins
       autoload :SaneDefaults, File.expand_path('../action/sane_defaults',__FILE__)
       autoload :SetupPackageFiles, File.expand_path('../action/setup_package_files', __FILE__)
       autoload :SetName, File.expand_path('../action/set_name', __FILE__)
+      autoload :SnapshotDelete, File.expand_path('../action/snapshot_delete', __FILE__)
+      autoload :SnapshotRestore, File.expand_path('../action/snapshot_restore', __FILE__)
+      autoload :SnapshotSave, File.expand_path('../action/snapshot_save', __FILE__)
       autoload :Suspend, File.expand_path('../action/suspend', __FILE__)
     end
   end

--- a/test/acceptance/provider/snapshot_spec.rb
+++ b/test/acceptance/provider/snapshot_spec.rb
@@ -1,0 +1,63 @@
+shared_examples 'provider/snapshot' do |provider, options|
+  if !options[:box]
+    raise ArgumentError,
+      "box option must be specified for provider: #{provider}"
+  end
+
+  include_context 'acceptance'
+
+  before do
+    assert_execute('vagrant', 'box', 'add', 'box', options[:box])
+    assert_execute('vagrant', 'init', 'box')
+    assert_execute('vagrant', 'up', "--provider=#{provider}")
+  end
+
+  after do
+    assert_execute('vagrant', 'destroy', '--force')
+  end
+
+  it 'can save, list and delete machine snapshots' do
+    status('Test: two snapshots could be created')
+    assert_execute('vagrant', 'snapshot', 'save', 'foo')
+    assert_execute('vagrant', 'snapshot', 'save', 'bar')
+
+    status('Test: snapshots show up in list')
+    result = execute('vagrant', 'snapshot', 'list')
+    expect(result).to exit_with(0)
+    expect(result.stdout).to match(/^foo$/)
+    expect(result.stdout).to match(/^bar$/)
+
+    status('Test: snapshots could be restored')
+    assert_execute('vagrant', 'snapshot', 'restore', 'foo')
+    assert_execute('vagrant', 'snapshot', 'restore', 'bar')
+
+    status('Test: snapshots could be deleted')
+    assert_execute('vagrant', 'snapshot', 'delete', 'foo')
+    assert_execute('vagrant', 'snapshot', 'delete', 'bar')
+
+    result = execute('vagrant', 'snapshot', 'list')
+    expect(result).to exit_with(0)
+    expect(result.stdout).not_to match(/^foo$/)
+    expect(result.stdout).not_to match(/^bar$/)
+  end
+
+  it 'can push and pop snapshots' do
+    status('Test: snapshot push')
+    result = execute('vagrant', 'snapshot', 'push')
+    expect(result).to exit_with(0)
+    expect(result.stdout).to match(/push_/)
+
+    status('Test: pushed snapshot shows up in list')
+    result = execute('vagrant', 'snapshot', 'list')
+    expect(result).to exit_with(0)
+    expect(result.stdout).to match(/^push_/)
+
+    status('Test: snapshot pop')
+    assert_execute('vagrant', 'snapshot', 'pop')
+
+    status('Test: popped snapshot has been deleted')
+    result = execute('vagrant', 'snapshot', 'list')
+    expect(result).to exit_with(0)
+    expect(result.stdout).not_to match(/push_/)
+  end
+end


### PR DESCRIPTION
Fixes #253

Completes "Snapshot" feature support introduced by https://github.com/Parallels/vagrant-parallels/pull/228

Now actions are defined, so the following commands should work fine with our provider: 
`vagrant snapshot save|restore|delete|push|pop`