### PR TITLE
Disable home folder sharing by default (Parallels Desktop 11+)

### DIFF
--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -61,7 +61,8 @@ module VagrantPlugins
           settings.merge!(
             startup_view: 'headless',
             time_sync: 'on',
-            disable_timezone_sync: 'on'
+            disable_timezone_sync: 'on',
+            shf_host_defined: 'off'
           )
 
           settings


### PR DESCRIPTION
Implements GH-171 for Parallels Desktop 11+

Due to request GH-171 there was a new CLI option added in PD 11:
```
prlctl set <vm_uuid> --shf-host-defined <off|alldisks|home>
```
By default all Parallels Desktop VMs has this option set to `"home"`, so that user's home folder (from the Mac host) is accessible for read & write from the guest VMs. In Linux VMs its content could be found at `/media/psf/Home`

I suggest to set this option to `off` for all VMs managed by our Vagrant provider, as we do for other host<=>guest integration features (see GH-215). This is needed for security reasons and helps to isolate dev environment from the Mac host.

cc: @Kasen @racktear 