### PR TITLE
config: Add warning message about deprecated options

### DIFF
--- a/lib/vagrant-parallels/config.rb
+++ b/lib/vagrant-parallels/config.rb
@@ -13,12 +13,12 @@ module VagrantPlugins
       attr_accessor :regen_src_uuid
       attr_accessor :update_guest_tools
 
+      # Deprecated options
+      attr_accessor :regen_box_uuid
+      attr_accessor :use_linked_clone
+
       # Compatibility with virtualbox provider's syntax
       alias :check_guest_additions= :check_guest_tools=
-
-      # Compatibility with old names
-      alias :regen_box_uuid= :regen_src_uuid=
-      alias :use_linked_clone= :linked_clone=
 
       def initialize
         @check_guest_tools = UNSET_VALUE
@@ -34,6 +34,10 @@ module VagrantPlugins
         @update_guest_tools = UNSET_VALUE
 
         network_adapter(0, :shared)
+
+        # Deprecated options
+        @regen_box_uuid = UNSET_VALUE
+        @use_linked_clone = UNSET_VALUE
       end
 
       def customize(*command)
@@ -55,10 +59,6 @@ module VagrantPlugins
         customize('pre-boot', ['set', :id, '--cpus', count.to_i])
       end
 
-      def regen_box_uuid=(value)
-        @regen_src_uuid = value
-      end
-
       def merge(other)
         super.tap do |result|
           c = customizations.dup
@@ -68,6 +68,16 @@ module VagrantPlugins
       end
 
       def finalize!
+        if @regen_box_uuid != UNSET_VALUE
+          puts "Parallels provider: Vagrantfile option 'regen_box_uuid' is deprecated and will be removed. Please, use 'regen_src_uuid' instead"
+          @regen_src_uuid = @regen_box_uuid if @regen_src_uuid == UNSET_VALUE
+        end
+
+        if @use_linked_clone != UNSET_VALUE
+          puts "Parallels provider: Vagrantfile option 'use_linked_clone' is deprecated and will be removed. Please, use 'linked_clone' instead"
+          @linked_clone = @use_linked_clone if @linked_clone == UNSET_VALUE
+        end
+
         if @check_guest_tools == UNSET_VALUE
           @check_guest_tools = true
         end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -19,10 +19,6 @@ describe VagrantPlugins::Parallels::Config do
     end
   end
 
-  def valid_defaults
-    subject.image = 'foo'
-  end
-
   before do
     vm_config = double('vm_config')
     vm_config.stub(networks: [])
@@ -39,10 +35,11 @@ describe VagrantPlugins::Parallels::Config do
   context 'defaults' do
     before { subject.finalize! }
 
-    it { expect(subject.check_guest_additions).to be_true }
+    it { expect(subject.check_guest_tools).to eq(true) }
     it { expect(subject.name).to be_nil }
-    it { expect(subject.functional_psf).to be_true }
-    it { expect(subject.optimize_power_consumption).to be_true }
+    it { expect(subject.functional_psf).to eq(true) }
+    it { expect(subject.linked_clone).to eq(false) }
+    it { expect(subject.regen_src_uuid).to eq(true) }
 
     it 'should have one Shared adapter' do
       expect(subject.network_adapters).to eql({

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -88,4 +88,34 @@ describe VagrantPlugins::Parallels::Config do
         [:bridged, auto_config: true])
     end
   end
+
+  describe '#linked_clone' do
+    it 'is compatible with deprecated use_linked_lone' do
+      subject.use_linked_clone = true
+      subject.finalize!
+      expect(subject.linked_clone).to eql(true)
+    end
+
+    it 'is not overridden by use_linked_lone' do
+      subject.linked_clone = false
+      subject.use_linked_clone = true
+      subject.finalize!
+      expect(subject.linked_clone).to eql(false)
+    end
+  end
+
+  describe '#regen_src_uuid' do
+    it 'is compatible with deprecated regen_box_uuid' do
+      subject.regen_box_uuid = false
+      subject.finalize!
+      expect(subject.regen_src_uuid).to eql(false)
+    end
+
+    it 'is not overridden by regen_box_uuid' do
+      subject.regen_src_uuid = true
+      subject.regen_box_uuid = false
+      subject.finalize!
+      expect(subject.regen_src_uuid).to eql(true)
+    end
+  end
 end


### PR DESCRIPTION
Vagrantfile options `regen_box_uuid` and `use_linked_clone` are marked as deprecated in favor of `regen_src_uuid ` and `linked_clone` appropriately.

Old options are still working, but will be removed in `vagrant-parallels` v1.7.0

cc: @racktear 