### PR TITLE
action/box_unregister: Fix #recover for layered envs

### DIFF
--- a/lib/vagrant-parallels/action/box_unregister.rb
+++ b/lib/vagrant-parallels/action/box_unregister.rb
@@ -33,6 +33,9 @@ module VagrantPlugins
         end
 
         def recover(env)
+          # If we don't have a box, nothing to do
+          return if !env[:machine].box
+
           unregister_box(env)
         end
 


### PR DESCRIPTION
There is no box specified in layered env. So, this action recovery should be just skipped.
cc @ar7em