### PR TITLE
Support for packaging linked clones

### DIFF
--- a/lib/vagrant-parallels/action/export.rb
+++ b/lib/vagrant-parallels/action/export.rb
@@ -12,8 +12,18 @@ module VagrantPlugins
             raise Vagrant::Errors::VMPowerOffToPackage
           end
 
+          # Clone source VM to the temporary copy
           clone(env)
+          @home_path = env[:machine].provider.driver.read_settings(env[:package_box_id]).fetch('Home')
+          @hdd_list = Dir.glob(File.join(@home_path, '*.hdd'))
+
+          # Convert to full-sized VM, copy all external and linked disks (if any)
+          convert_to_full(env)
+
+          # Compact all virtual disks
           compact(env)
+
+          # Preparations completed. Unregister before packaging
           unregister_vm(env)
 
           @app.call(env)
@@ -71,16 +81,69 @@ module VagrantPlugins
           env[:ui].clear_line
         end
 
-        def compact(env)
-          env[:ui].info I18n.t('vagrant_parallels.actions.vm.export.compacting')
-          env[:machine].provider.driver.compact(env[:package_box_id]) do |progress|
-            env[:ui].clear_line
-            env[:ui].report_progress(progress, 100, false)
+        def convert_to_full(env)
+          is_linked = false
+
+          @hdd_list.each do |hdd_dir|
+            disk_desc = File.join(hdd_dir, 'DiskDescriptor.xml')
+            xml = Nokogiri::XML(File.open disk_desc)
+
+            linked_images = xml.xpath('//Parallels_disk_image/StorageData/Storage/Image/File').select do |hds|
+              Pathname.new(hds).absolute?
+            end
+
+            # If this is a regular, not linked HDD, then skip it. Otherwise,
+            # remember this VM as a linked clone.
+            next if linked_images.empty?
+            is_linked = true
+
+
+            env[:ui].info I18n.t('vagrant_parallels.actions.vm.export.copying_linked_disks')
+            linked_images.each do |hds|
+              hds_path = hds.text
+
+              if !File.exist?(hds_path)
+                raise VagrantPlugins::Parallels::Errors::ExternalDiskNotFound,
+                      path: hds_path
+              end
+
+              FileUtils.cp(hds_path, hdd_dir, preserve: true)
+
+              # Save relative hds path to the XML file
+              hds.content = File.basename(hds_path)
+            end
+
+            File.open(disk_desc, 'w') do |f|
+              f.write xml.to_xml
+            end
           end
 
-          # Clear the line a final time so the next data can appear
-          # alone on the line.
-          env[:ui].clear_line
+          # Flush elements LinkedVmUuid, LinkedSnapshotUuid from "config.pvs"
+          if is_linked
+            @logger.debug 'Converting linked clone to the regular VM'
+            config_pvs = File.join(@home_path, 'config.pvs')
+
+            xml = Nokogiri::XML(File.open(config_pvs))
+            xml.xpath('//ParallelsVirtualMachine/Identification/LinkedVmUuid').first.content = ''
+            xml.xpath('//ParallelsVirtualMachine/Identification/LinkedSnapshotUuid').first.content = ''
+
+            File.open(config_pvs, 'w') do |f|
+              f.write xml.to_xml
+            end
+          end
+        end
+
+        def compact(env)
+          env[:ui].info I18n.t('vagrant_parallels.actions.vm.export.compacting')
+          @hdd_list.each do |hdd|
+            env[:machine].provider.driver.compact_hdd(hdd) do |progress|
+              env[:ui].clear_line
+              env[:ui].report_progress(progress, 100, false)
+            end
+            # Clear the line a final time so the next data can appear
+            # alone on the line.
+            env[:ui].clear_line
+          end
         end
 
         def unregister_vm(env)

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -82,20 +82,16 @@ module VagrantPlugins
           read_vms[dst_name]
         end
 
-        # Compacts all disk drives of virtual machine
-        def compact(uuid)
-          hw_info = read_settings(uuid).fetch('Hardware', {})
-          used_drives = hw_info.select do |name, _|
-            name.start_with? 'hdd'
-          end
-          used_drives.each_value do |drive_params|
-            execute(@prldisktool_path, 'compact', '--hdd', drive_params['image']) do |_, data|
-              lines = data.split('\r')
-              # The progress of the compact will be in the last line. Do a greedy
-              # regular expression to find what we're looking for.
-              if lines.last =~ /.+?(\d{,3}) ?%/
-                yield $1.to_i if block_given?
-              end
+        # Compacts the specified virtual disk image
+        #
+        # @param [<String>] hdd_path Path to the target '*.hdd'
+        def compact_hdd(hdd_path)
+          execute(@prldisktool_path, 'compact', '--hdd', hdd_path) do |_, data|
+            lines = data.split('\r')
+            # The progress of the compact will be in the last line. Do a greedy
+            # regular expression to find what we're looking for.
+            if lines.last =~ /.+?(\d{,3}) ?%/
+              yield $1.to_i if block_given?
             end
           end
         end

--- a/lib/vagrant-parallels/driver/meta.rb
+++ b/lib/vagrant-parallels/driver/meta.rb
@@ -74,7 +74,7 @@ module VagrantPlugins
         def_delegators :@driver,
                        :clear_forwarded_ports,
                        :clear_shared_folders,
-                       :compact,
+                       :compact_hdd,
                        :create_host_only_network,
                        :create_snapshot,
                        :delete,

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -19,6 +19,10 @@ module VagrantPlugins
         error_key(:dhcp_leases_file_not_accessible)
       end
 
+      class ExternalDiskNotFound < VagrantParallelsError
+        error_key(:external_disk_not_found)
+      end
+
       class JSONParseError < VagrantParallelsError
         error_key(:json_parse_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -38,6 +38,13 @@ en:
         JSON string is shown below:
 
         %{data}
+
+      external_disk_not_found: |-
+        External disk image could not be found. In case of linked clone it is
+        usually because the parent VM image was removed. It means that the virtual
+        disk is inconsistent, please remove it from the VM configuration.
+
+        Disk image path: %{path}
       linux_mount_failed: |-
         Failed to mount folders in Linux guest. This is usually because
         the "prl_fs" file system is not available. Please verify that
@@ -211,6 +218,7 @@ en:
             reload your VM.
         export:
           compacting: Compacting exported HDDs...
+          copying_linked_disks: Copying linked disks...
         forward_ports:
           forwarding_entry: |-
             %{guest_port} => %{host_port}

--- a/test/acceptance/provider/package_spec.rb
+++ b/test/acceptance/provider/package_spec.rb
@@ -1,0 +1,68 @@
+# This tests that packaging works with a given provider.
+shared_examples 'provider/package' do |provider, options|
+  if !options[:box]
+    raise ArgumentError,
+          "box option must be specified for provider: #{provider}"
+  end
+
+  include_context 'acceptance'
+
+  it "can't package before an up" do
+    expect(execute('vagrant', 'package')).to exit_with(1)
+  end
+
+  context 'with a running machine' do
+    before do
+      # Create VM as a linked clone to test that it could be packaged correctly
+      environment.skeleton('linked_clone')
+
+      assert_execute('vagrant', 'box', 'add', 'basic', options[:box])
+      assert_execute('vagrant', 'up', "--provider=#{provider}")
+    end
+
+    after do
+      # Just always do this just in case
+      execute('vagrant', 'destroy', '--force', log: false)
+    end
+
+    it 'can package and bring the box back up' do
+      status('Test: linked clone could be packaged to the standalone box')
+      expect(execute('vagrant', 'package')).to exit_with(0)
+      assert_execute('vagrant', 'destroy', '--force')
+
+      path = environment.workdir.join('package.box')
+      expect(path).to be_file
+
+      begin
+        # Create a new environment and bring up the packaged box
+        status('Test: packaged box could be reused')
+        new_env = new_environment
+        assert_execute('vagrant', 'box', 'add', 'temp', path.to_s, env: new_env)
+        assert_execute('vagrant', 'init', 'temp', env: new_env)
+        assert_execute('vagrant', 'up', "--provider=#{provider}", env: new_env)
+
+        # Test again for Vagrant issue GH-5780
+        status('Test: box could be re-package (issue mitchellh/vagrant#5780)')
+        assert_execute('vagrant', 'package', env: new_env)
+        assert_execute('vagrant', 'destroy', '--force', env: new_env)
+
+        path = new_env.workdir.join('package.box')
+        new_env2 = new_environment
+        assert_execute('vagrant', 'box', 'add', 'temp', path.to_s, env: new_env2)
+        assert_execute('vagrant', 'init', 'temp', env: new_env2)
+        assert_execute('vagrant', 'up', "--provider=#{provider}", env: new_env)
+        assert_execute('vagrant', 'destroy', '--force', env: new_env2)
+      ensure
+        if new_env
+          new_env.execute('vagrant', 'destroy', '--force')
+          new_env.close
+        end
+
+        if new_env2
+          new_env2.execute('vagrant', 'destroy', '--force')
+          new_env2.close
+        end
+      end
+    end
+  end
+end

--- a/test/unit/support/shared/pd_driver_examples.rb
+++ b/test/unit/support/shared/pd_driver_examples.rb
@@ -3,17 +3,13 @@ shared_examples 'parallels desktop driver' do |options|
     raise ArgumentError, 'Need parallels context to use these shared examples.' unless defined? parallels_context
   end
 
-  describe 'compact' do
-    settings = {'Hardware' => {'hdd0' => {'image' => '/path/to/disk0.hdd'},
-                               'hdd1' => {'image' => '/path/to/disk1.hdd'}}}
-    it 'compacts the VM disk drives' do
-      driver.should_receive(:read_settings).and_return(settings)
-
-      subprocess.should_receive(:execute).exactly(2).times.
-        with('prl_disk_tool', 'compact', '--hdd', /^\/path\/to\/disk(0|1).hdd$/,
+  describe 'compact_hdd' do
+    it 'compacts the virtual disk' do
+      subprocess.should_receive(:execute).
+        with('prl_disk_tool', 'compact', '--hdd', '/foo.hdd',
              an_instance_of(Hash)).
         and_return(subprocess_result(exit_code: 0))
-      subject.compact(uuid)
+      subject.compact_hdd('/foo.hdd')
     end
   end
 


### PR DESCRIPTION
This PR makes possible to use `vagrant package` for environments created as linked clones.
External disk images will be automatically copied, so the resulted box become a full-sized standalone VM.

cc: @Kasen, @racktear, @Gray-Wind 