### PR TITLE
Fix an exception when the host is not connected to host-only interface

### DIFF
--- a/lib/vagrant-parallels/action/network.rb
+++ b/lib/vagrant-parallels/action/network.rb
@@ -444,20 +444,18 @@ module VagrantPlugins
 
         # This finds a matching host only network for the given configuration.
         def hostonly_find_matching_network(config)
-          existing = @env[:machine].provider.driver.read_host_only_interfaces
+          this_netaddr = network_address(config[:ip], config[:netmask])
 
-          if config[:name]
-            # Search networks strongly by specified name
-            matched_iface = existing.detect { |i| config[:name] == i[:name] }
-          else
-            # Name is not specified - search by network address
-            this_netaddr = network_address(config[:ip], config[:netmask])
-            matched_iface = existing.detect do |i|
-              this_netaddr == network_address(i[:ip], i[:netmask])
+          @env[:machine].provider.driver.read_host_only_interfaces.each do |interface|
+            return interface if config[:name] && config[:name] == interface[:name]
+
+            if interface[:ip]
+              return interface if this_netaddr == \
+                network_address(interface[:ip], interface[:netmask])
             end
           end
 
-          matched_iface || nil
+          nil
         end
       end
     end

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -406,6 +406,15 @@ module VagrantPlugins
         end
 
         # Returns a list of available host only interfaces.
+        # Each interface is represented as a Hash with the following details:
+        #
+        # {
+        #   name:     'Host-Only',     # Parallels Network ID
+        #   bound_to: 'vnic1',         # interface name
+        #   ip:       '10.37.129.2',   # IP address of the interface
+        #   netmask:  '255.255.255.0', # netmask associated with the interface
+        #   status:   'Up'             # status of the interface
+        # }
         #
         # @return [Array<Symbol => String>]
         def read_host_only_interfaces

--- a/lib/vagrant-parallels/driver/pd_10.rb
+++ b/lib/vagrant-parallels/driver/pd_10.rb
@@ -149,17 +149,6 @@ module VagrantPlugins
               iface[:status]   = 'Up'
             end
 
-            # There may be a fake DHCPv4 parameters
-            # We can trust them only if adapter IP and DHCP IP are in the same subnet
-            dhcp_info = net_info['DHCPv4 server']
-            if dhcp_info && (network_address(iface[:ip], iface[:netmask]) ==
-              network_address(dhcp_info['Server address'], iface[:netmask]))
-              iface[:dhcp] = {
-                ip:    dhcp_info['Server address'],
-                lower: dhcp_info['IP scope start address'],
-                upper: dhcp_info['IP scope end address']
-              }
-            end
             hostonly_ifaces << iface
           end
           hostonly_ifaces

--- a/lib/vagrant-parallels/driver/pd_8.rb
+++ b/lib/vagrant-parallels/driver/pd_8.rb
@@ -115,17 +115,6 @@ module VagrantPlugins
               iface[:status]   = 'Up'
             end
 
-            # There may be a fake DHCPv4 parameters
-            # We can trust them only if adapter IP and DHCP IP are in the same subnet
-            dhcp_info = net_info['DHCPv4 server']
-            if dhcp_info && (network_address(iface[:ip], iface[:netmask]) ==
-              network_address(dhcp_info['Server address'], iface[:netmask]))
-              iface[:dhcp] = {
-                ip:    dhcp_info['Server address'],
-                lower: dhcp_info['IP scope start address'],
-                upper: dhcp_info['IP scope end address']
-              }
-            end
             hostonly_ifaces << iface
           end
           hostonly_ifaces


### PR DESCRIPTION
Similarly to the problem described in #266, Host-Only interfaces could be also not connected to the host machine, so it causes an exception when Vagrant tries to parse its IP:

```
       stderr: /Users/legal/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bundler/gems/vagrant-a4f45a18a653/lib/vagrant/util/network_ip.rb:35:in `ip_parts': undefined method `split' for nil:NilClass (NoMethodError)
       	from /Users/legal/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bundler/gems/vagrant-a4f45a18a653/lib/vagrant/util/network_ip.rb:19:in `network_address'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:454:in `block in hostonly_find_matching_network'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:449:in `each'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:449:in `hostonly_find_matching_network'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:323:in `hostonly_adapter'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:92:in `block (3 levels) in call'
       	from /Users/legal/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bundler/gems/vagrant-a4f45a18a653/lib/vagrant/environment.rb:561:in `lock'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:91:in `block (2 levels) in call'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:89:in `synchronize'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:89:in `block in call'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:75:in `each'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/network.rb:75:in `call'
```

This PR fixes that error by an additional check. 
Also, I've removed fetching DHCP details from driver's method `#read_host_only_interfaces`, because it is actually not needed for `Network` action.