### PR TITLE
IPv6 support for Host-Only networks (PD 12+)

### DIFF
--- a/lib/vagrant-parallels/action/network.rb
+++ b/lib/vagrant-parallels/action/network.rb
@@ -1,5 +1,5 @@
+require 'ipaddr'
 require 'set'
-
 require 'log4r'
 
 require 'vagrant/util/network_ip'
@@ -253,7 +253,6 @@ module VagrantPlugins
             mac:         nil,
             name:        nil,
             nic_type:    nil,
-            netmask:     '255.255.255.0',
             type:        :static
           }.merge(options)
 
@@ -263,30 +262,46 @@ module VagrantPlugins
           # Default IP is in the 20-bit private network block for DHCP based networks
           options[:ip] = '10.37.129.1' if options[:type] == :dhcp && !options[:ip]
 
-          # Calculate our network address for the given IP/netmask
-          netaddr  = network_address(options[:ip], options[:netmask])
+          # TODO: catch wrong type exception
+          ip = IPAddr.new(options[:ip])
+          if ip.ipv4?
+            options[:netmask] ||= '255.255.255.0'
 
-          # Verify that a host-only network subnet would not collide
-          # with a bridged networking interface.
-          #
-          # If the subnets overlap in any way then the host only network
-          # will not work because the routing tables will force the
-          # traffic onto the real interface rather than the virtual
-          # network interface.
-          @env[:machine].provider.driver.read_bridged_interfaces.each do |interface|
-            that_netaddr = network_address(interface[:ip], interface[:netmask])
-            raise Vagrant::Errors::NetworkCollision if \
-              netaddr == that_netaddr && interface[:status] != 'Down'
+            # Calculate our network address for the given IP/netmask
+            netaddr  = network_address(options[:ip], options[:netmask])
+
+            # Verify that a host-only network subnet would not collide
+            # with a bridged networking interface.
+            #
+            # If the subnets overlap in any way then the host only network
+            # will not work because the routing tables will force the
+            # traffic onto the real interface rather than the virtual
+            # network interface.
+            @env[:machine].provider.driver.read_bridged_interfaces.each do |interface|
+              that_netaddr = network_address(interface[:ip], interface[:netmask])
+              raise Vagrant::Errors::NetworkCollision if \
+                netaddr == that_netaddr && interface[:status] != 'Down'
+            end
+
+            # Split the IP address into its components
+            ip_parts = netaddr.split('.').map { |i| i.to_i }
+
+            # Calculate the adapter IP, which we assume is the IP ".1" at
+            # the end usually.
+            adapter_ip    = ip_parts.dup
+            adapter_ip[3] += 1
+            options[:adapter_ip] ||= adapter_ip.join('.')
+          elsif ip.ipv6?
+            options[:netmask] ||= 64
+
+            # Set adapter IP to <prefix>::1
+            options[:adapter_ip] ||= (ip.mask(options[:netmask].to_i) | 1).to_s
+
+            # Append a 6 to the end of the type
+            options[:type] = "#{options[:type]}6".to_sym
+          else
+            raise "BUG: Unknown IP type: #{ip.inspect}"
           end
-
-          # Split the IP address into its components
-          ip_parts = netaddr.split('.').map { |i| i.to_i }
-
-          # Calculate the adapter IP, which we assume is the IP ".1" at
-          # the end usually.
-          adapter_ip    = ip_parts.dup
-          adapter_ip[3] += 1
-          options[:adapter_ip] ||= adapter_ip.join('.')
 
           dhcp_options = {}
           if options[:type] == :dhcp
@@ -452,6 +467,11 @@ module VagrantPlugins
             if interface[:ip]
               return interface if this_netaddr == \
                 network_address(interface[:ip], interface[:netmask])
+            end
+
+            if interface[:ipv6]
+              return interface if this_netaddr == \
+                network_address(interface[:ipv6], interface[:ipv6_prefix])
             end
           end
 

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -524,6 +524,11 @@ module VagrantPlugins
               iface[:netmask]  = adapter['Subnet mask'] || adapter['IPv4 subnet mask']
               iface[:bound_to] = net_info['Bound To']
               iface[:status]   = 'Up'
+
+              if adapter['IPv6 address'] && adapter['IPv6 subnet mask']
+                iface[:ipv6]        = adapter['IPv6 address']
+                iface[:ipv6_prefix] = adapter['IPv6 subnet mask']
+              end
             end
 
             hostonly_ifaces << iface

--- a/lib/vagrant-parallels/driver/pd_12.rb
+++ b/lib/vagrant-parallels/driver/pd_12.rb
@@ -14,6 +14,42 @@ module VagrantPlugins
 
           @logger = Log4r::Logger.new('vagrant_parallels::driver::pd_12')
         end
+
+        def create_host_only_network(options)
+          # Create the interface
+          execute_prlsrvctl('net', 'add', options[:network_id], '--type', 'host-only')
+
+          # Get the IP so we can determine v4 vs v6
+          ip = IPAddr.new(options[:adapter_ip])
+          if ip.ipv4?
+            args = ['--ip', "#{options[:adapter_ip]}/#{options[:netmask]}"]
+            if options[:dhcp]
+              args.concat(['--dhcp-ip', options[:dhcp][:ip],
+                           '--ip-scope-start', options[:dhcp][:lower],
+                           '--ip-scope-end', options[:dhcp][:upper]])
+            end
+          elsif ip.ipv6?
+            # Convert prefix length to netmask ("32" -> "ffff:ffff::")
+            options[:netmask] = IPAddr.new(IPAddr::IN6MASK, Socket::AF_INET6)
+                                  .mask(options[:netmask]).to_s
+
+            args = ['--host-assign-ip6', 'on',
+                    '--ip6', "#{options[:adapter_ip]}/#{options[:netmask]}"]
+            # DHCPv6 setting is not supported by Vagrant yet.
+          else
+            raise IPAddr::AddressFamilyError, 'BUG: unknown address family'
+          end
+
+          execute_prlsrvctl('net', 'set', options[:network_id], *args)
+
+          # Return the details
+          {
+            name:    options[:network_id],
+            ip:      options[:adapter_ip],
+            netmask: options[:netmask],
+            dhcp:    options[:dhcp]
+          }
+        end
       end
     end
   end

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -39,6 +39,10 @@ module VagrantPlugins
         error_key(:mac_os_x_required)
       end
 
+      class NetworkInvalidAddress < VagrantParallelsError
+        error_key(:network_invalid_address)
+      end
+
       class ExecutionError < VagrantParallelsError
         error_key(:execution_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -58,6 +58,11 @@ en:
         which are not supported by "prl_fs" file system.
 
         Invalid mount options: %{options}
+      network_invalid_address: |-
+        Network settings specified in your Vagrantfile are invalid:
+
+        Network settings: %{options}
+        Error: %{error}
       mac_os_x_required: |-
         Parallels provider works only on OS X (Mac OS X) systems.
       parallels_install_incomplete: |-

--- a/test/unit/action/network_test.rb
+++ b/test/unit/action/network_test.rb
@@ -255,4 +255,22 @@ describe VagrantPlugins::Parallels::Action::Network do
 
   end
 
+  context 'with invalid settings' do
+    [
+      { ip: 'foo'},
+      { ip: '1.2.3'},
+      { ip: 'dead::beef::'},
+      { ip: '172.28.128.3', netmask: 64},
+      { ip: '172.28.128.3', netmask: 'ffff:ffff::'},
+      { ip: 'dead:beef::', netmask: 'foo:bar::'},
+      { ip: 'dead:beef::', netmask: '255.255.255.0'}
+    ].each do |args|
+      it 'raises an exception' do
+        machine.config.vm.network 'private_network', **args
+        expect { subject.call(env) }.
+          to raise_error(VagrantPlugins::Parallels::Errors::NetworkInvalidAddress)
+      end
+    end
+  end
+
 end

--- a/test/unit/action/network_test.rb
+++ b/test/unit/action/network_test.rb
@@ -139,6 +139,36 @@ describe VagrantPlugins::Parallels::Action::Network do
         )
       end
     end
+
+    context 'with static ipv6' do
+      let(:network_args) {{ ip: 'dead:beef::100' }}
+
+      it 'creates a host-only interface with an IPv6 address <prefix>:1' do
+        allow(driver).to receive(:create_host_only_network) {{ name: 'vagrant-vnet0' }}
+        interface_ip = 'dead:beef::1'
+
+        subject.call(env)
+
+        expect(driver).to have_received(:create_host_only_network).with(
+          {
+            network_id: 'vagrant-vnet0',
+            adapter_ip: interface_ip,
+            netmask: 64,
+          }
+        )
+
+        expect(guest).to have_received(:capability).with(
+          :configure_networks, [{
+                                  type: :static6,
+                                  adapter_ip: interface_ip,
+                                  ip: 'dead:beef::100',
+                                  netmask: 64,
+                                  auto_config: true,
+                                  interface: nil
+                                }]
+        )
+      end
+    end
   end
 
   context 'with public network' do


### PR DESCRIPTION
**NB!** This feature is supported only for Parallels Desktop 12 and higher. This is caused by the `prlctl` option `--host-assign-ip6 on` appeared in PD 12. Without this option, by the default behavior the host's interface will not be configured with IPv6 address.

This PR is a partial port of https://github.com/mitchellh/vagrant/pull/6342. Also, it includes some enhancements from https://github.com/mitchellh/vagrant/pull/7699.