### PR TITLE
Disable Parallels Desktop feature "--tools-autoupdate"

### DIFF
--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -31,6 +31,7 @@ module VagrantPlugins
 
         def default_settings
           settings = {
+            tools_autoupdate: 'no',
             startup_view: 'same',
             on_shutdown: 'close',
             on_window_close: 'keep-running',


### PR DESCRIPTION
Fixes the following issues:
- #281
- https://github.com/chef/bento/issues/695

The details are explained in this comment: https://github.com/Parallels/vagrant-parallels/issues/281#issuecomment-264632082

TL;DR: We should disable the built-in Parallels Desktop feature of auto-updating Parallels Tools in VMs because it collides with the similar feature managed by our Vagrant provider and could cause provision failures.

If you want to keep Parallels Tools in your VMs up-to-date, please, enable an appropriate provider feature:
```ruby
config.vm.provider "parallels" do |prl|
  prl.update_guest_tools = true
end
```

cc: @romankulikov 