### PR TITLE
Implement "install_parallels_tools" guest capability for Windows

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -452,7 +452,7 @@ module VagrantPlugins
           iso_name ={
             linux: 'prl-tools-lin.iso',
             darwin: 'prl-tools-mac.iso',
-            windows: 'prl-tools-win.iso'
+            windows: 'PTIAgent.exe'
           }
           return nil if !iso_name[guest_os]
 

--- a/lib/vagrant-parallels/guest_cap/windows/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/windows/install_parallels_tools.rb
@@ -1,0 +1,35 @@
+module VagrantPlugins
+  module Parallels
+    module GuestWindowsCap
+      class InstallParallelsTools
+        def self.install_parallels_tools(machine)
+          machine.communicate.tap do |comm|
+            pti_agent_path = File.expand_path(
+              machine.provider.driver.read_guest_tools_iso_path('windows'),
+              machine.env.root_path
+            )
+
+            remote_file = '$env:TEMP\PTIAgent.exe'
+            comm.upload(pti_agent_path, remote_file)
+
+            install_script = <<-EOH
+            Start-Process -FilePath #{remote_file} `
+              -ArgumentList "/install_silent" `
+              -Verb RunAs `
+              -Wait
+            EOH
+
+            cleanup_script = <<-EOH
+            If (Test-Path #{remote_file}){
+              Remove-Item #{remote_file}
+            }
+            EOH
+
+            comm.execute(install_script)
+            comm.execute(cleanup_script)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -68,6 +68,11 @@ module VagrantPlugins
         GuestLinuxCap::InstallParallelsTools
       end
 
+      guest_capability(:windows, :install_parallels_tools) do
+        require_relative 'guest_cap/windows/install_parallels_tools'
+        GuestWindowsCap::InstallParallelsTools
+      end
+
       provider_capability(:parallels, :public_address) do
         require_relative 'cap'
         Cap

--- a/website/docs/source/docs/configuration.html.md
+++ b/website/docs/source/docs/configuration.html.md
@@ -55,13 +55,6 @@ that box deletion will cause all its linked clones being corrupted. Then please,
 delete your boxes carefully!
 
 ## Parallels Tools Auto-Update
-<div class="alert alert-info">
-	<p>
-        <strong>Note:</strong> This feature makes sense to Linux and OS X guests 
-        only. In Windows guests Parallels Tools will be always updated
-        automatically by the special installation agent running in GUI mode.
-	</p>
-</div>
 
 Parallels Tools is a set of Parallels utilities that ensures a high level of
 integration between the host and the guest operating systems (read more:


### PR DESCRIPTION
This PR adds a possibility to update Parallels Tools in Windows guests using the common provider option:
```ruby
config.vm.provider "parallels" do |prl|
  prl.update_guest_tools = true
end
```

It was working fine for Linux and Mac OS X guests for a while.

Until this moment, for Windows guests we were using the internal Parallels Desktop feature of auto-updating Parallels Tools. But now we are going to disable it globally (https://github.com/Parallels/vagrant-parallels/pull/283), so this PR provides a proper way to keep PT up-to-date in Windows guests as well.
