### PR TITLE
Fix "ptiagent" argument in "install_parallels_tools" guest cap

### DIFF
--- a/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
@@ -5,9 +5,7 @@ module VagrantPlugins
 
         def self.install_parallels_tools(machine)
           if ptiagent_usable?(machine)
-            # Argument '--info' means that Parallels Tools version will be
-            # checked before the installing.
-            machine.communicate.sudo('ptiagent-cmd --info')
+            machine.communicate.sudo('ptiagent-cmd --install')
           else
             machine.communicate.tap do |comm|
               tools_iso_path = File.expand_path(


### PR DESCRIPTION
It's pretty odd, but argument `--info` doesn't work if the internal feature `--tools-autoupdate` is disabled (we've disabled it in GH-283)
So we should use `--install` here since it always installs/updates Parallels Tools for Linux regardless of any other conditions.