### PR TITLE
Added "require 'nokogiri'"

### DIFF
--- a/lib/vagrant-parallels/action/export.rb
+++ b/lib/vagrant-parallels/action/export.rb
@@ -1,3 +1,5 @@
+require 'nokogiri'
+
 module VagrantPlugins
   module Parallels
     module Action


### PR DESCRIPTION
Attempting to run 'vagrant package --output mybox.box' was failing with:

.vagrant.d/gems/2.2.5/gems/vagrant-parallels-1.7.2/lib/vagrant-parallels/action/export.rb:89:in `block in convert_to_full': uninitialized constant VagrantPlugins::Parallels::Action::Export::Nokogiri (NameError)
	from /Users/steve/.vagrant.d/gems/2.2.5/gems/vagrant-parallels-1.7.2/lib/vagrant-parallels/action/export.rb:87:in `each'
	from /Users/steve/.vagrant.d/gems/2.2.5/gems/vagrant-parallels-1.7.2/lib/vagrant-parallels/action/export.rb:87:in `convert_to_full'
	from /Users/steve/.vagrant.d/gems/2.2.5/gems/vagrant-parallels-1.7.2/lib/vagrant-parallels/action/export.rb:21:in `call'
	...

Adding in the 'require' solves the problem