### PR TITLE
Make `start` action run provisioners if VM is running

### DIFF
--- a/lib/vagrant-parallels/action.rb
+++ b/lib/vagrant-parallels/action.rb
@@ -277,9 +277,10 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use BoxCheckOutdated
           b.use Call, IsState, :running do |env1, b1|
-            # If the VM is running, then our work here is done, exit
+            # If the VM is running, run the necessary provisioners
             if env1[:result]
               b1.use Message, I18n.t('vagrant_parallels.commands.common.vm_already_running')
+              action_provision
               next
             end
 


### PR DESCRIPTION
That is a port of the upstream Vagrant commit:
https://github.com/mitchellh/vagrant/commit/e42f346b1d5891b5bd3651564894b95ed3b8b6cc

>Previously, there was no one gesture that would start a VM if it was not
running and run the appropriate provisioners regardless of its original
state. `vagrant up` did nothing if the VM was running, while
`vagrant provision` did nothing if the VM was not running.

>Change the semantics of `vagrant up`, via the start actions of the providers,
to go through the provisioning logic even if the VM is already running.
The semantics of `run: "once"` vs `run: "always"` are respected.