### PR TITLE
Handle "paused" VM state for up and halt actions

### DIFF
--- a/lib/vagrant-parallels/action/resume.rb
+++ b/lib/vagrant-parallels/action/resume.rb
@@ -9,8 +9,12 @@ module VagrantPlugins
         def call(env)
           current_state = env[:machine].state.id
 
+          # Driver method "resume" works for suspended and paused state as well
           if current_state == :suspended
             env[:ui].info I18n.t('vagrant.actions.vm.resume.resuming')
+            env[:machine].provider.driver.resume
+          elsif current_state == :paused
+            env[:ui].info I18n.t('vagrant.actions.vm.resume.unpausing')
             env[:machine].provider.driver.resume
           end
 


### PR DESCRIPTION
At the moment VM could not be started/stopped/deleted if it is in `:paused` state (don't mix it up with `:suspended`). `prlctl` doesn't allow that by some reason:

```
$ prlctl stop paused-vm-name
Stopping the VM...
Failed to stop the VM: Unable to complete the operation. This operation cannot be completed because the virtual machine "paused-vm-name is in the "paused" state.

$ prlctl delete paused-vm-name
Removing the VM...
Failed to remove the VM: Unable to perform the action because the virtual machine is busy. The virtual machine is currently running. Please try again later.
```

This PR fixes the related issue - the VM will be resumed before the `halt` action. Also, on the `up` action it will be just resumed to avoid further errors while redundant re-configuration.