### PR TITLE
Escape backward slashes in synced folder id

### DIFF
--- a/lib/vagrant-parallels/synced_folder.rb
+++ b/lib/vagrant-parallels/synced_folder.rb
@@ -105,7 +105,8 @@ module VagrantPlugins
       end
 
       def os_friendly_id(id)
-        id.gsub(/[\/:]/,'_').sub(/^_/, '')
+        # Replace chars *, ", :, <, >, ?, |, /, \
+        id.gsub(/[*":<>?|\/\\]/,'_').sub(/^_/, '')
       end
     end
   end


### PR DESCRIPTION
That fixes invalid share names in Windows guests, where backward slash
character is used as a path separator.

_Details:_
Currently, if we define the synced folder this way (for Windows guest):
```ruby
config.vm.synced_folder "../", 'C:\Users\vagrant\my_share'
```
then the share id will be this string: `'C_\Users\vagrant\my_share'`
In the guest it will be exposed as `\\psf\C_Usersvagrantmy_share` - Parallels Desktop tries to replace backslashes with some special character by itself. Meanwhile the Vagrant expects that the 
share is available at `\\psf\C_Usersvagrantmy_share`, so it creates a broken symlink.

This Pull-Request adds `\` to the regex, so this char will be replaced with `_`.
The result share name will be `'C__Users_vagrant_my_share'` and it will be available at `\\psf\C__Users_vagrant_my_share` without any issues.

The similar PR has been sent to VirtualBox provider: https://github.com/mitchellh/vagrant/pull/8433