### PR TITLE
Add "nokogiri" as a runtime dependency

### DIFF
--- a/vagrant-parallels.gemspec
+++ b/vagrant-parallels.gemspec
@@ -16,10 +16,11 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.3.6'
   spec.rubyforge_project         = 'vagrant-parallels'
 
+  spec.add_dependency 'nokogiri'
+
   # Constraint rake to properly handle deprecated method usage
   # from within rspec
   spec.add_development_dependency 'rake', '~> 11.3.0'
-  spec.add_development_dependency 'nokogiri'
   spec.add_development_dependency 'rspec', '~> 2.14.0'
 
   spec.files = Dir['lib/**/*', 'locales/**/*', 'README.md', 'CHANGELOG.md', 'LICENSE.txt']


### PR DESCRIPTION
This PR fixes https://github.com/Parallels/vagrant-parallels/issues/297

In Vagrant 1.9.5 there was "nokogiri" gem removed from the Vagrant bundle: https://github.com/mitchellh/vagrant/pull/8571
So now we should specify it as a dependency of `vagrant-parallels` gem if we want to use it.

**NB!** After that PR is merged & released, it will cause a crash of plugin upgrade/installation with Vagrant 1.9.5, similar to this https://github.com/mitchellh/vagrant/issues/8594
To work it around we need to define a special env variable before running the plugin installation:

```
export NOKOGIRI_USE_SYSTEM_LIBRARIES=true 
vagrant plugin install vagrant-parallels
```

Hopefully, this trick will not be needed for future versions of Vagrant (after 1.9.5), since it was fixed in the Vagrant installer: https://github.com/mitchellh/vagrant-installers/pull/104
