### PR TITLE
fix link to vagrant downloads page

### DIFF
--- a/website/docs/source/docs/installation/index.html.md
+++ b/website/docs/source/docs/installation/index.html.md
@@ -5,7 +5,7 @@ sidebar_current: "installation"
 
 # Installing Provider
 First, make sure that you have [Parallels Desktop for Mac](http://www.parallels.com/products/desktop/)
-and [Vagrant](http://www.vagrantup.com/downloads) properly installed.
+and [Vagrant](http://www.vagrantup.com/downloads.html) properly installed.
 We recommend that you to use the latest versions of these products.
 
 Since the Parallels provider is a Vagrant plugin, installing it is easy:


### PR DESCRIPTION
The current installation doc links to `/downloads` on the vagrant site but the url is `/downloads.html`.