### PR TITLE
test/acceptance: Use correct environment when starting the guest

### DIFF
--- a/test/acceptance/provider/package_spec.rb
+++ b/test/acceptance/provider/package_spec.rb
@@ -50,7 +50,7 @@ shared_examples 'provider/package' do |provider, options|
         new_env2 = new_environment
         assert_execute('vagrant', 'box', 'add', 'temp', path.to_s, env: new_env2)
         assert_execute('vagrant', 'init', 'temp', env: new_env2)
-        assert_execute('vagrant', 'up', "--provider=#{provider}", env: new_env)
+        assert_execute('vagrant', 'up', "--provider=#{provider}", env: new_env2)
         assert_execute('vagrant', 'destroy', '--force', env: new_env2)
       ensure
         if new_env


### PR DESCRIPTION
Fixes #312 

P.s. Actually, the same issue was recently fixed in the upstream (virtualbox) implementation of `package_spec.rb`: https://github.com/hashicorp/vagrant-spec/commit/7ac8b4191de578e345b29acaf62ecc72c8e73be1