### PR TITLE
Update the documentation website

### DIFF
--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -14,7 +14,7 @@ requests like any normal GitHub project, and we'll merge it in.
 
 ## Running the Site Locally
 
-Running the site locally is simple. Clone this repo, switch to `website/docs/` 
+Running the site locally is simple. Clone this repo, switch to `website/docs/`
 and run the following commands:
 
 ```
@@ -27,12 +27,12 @@ Your local copy of the site should be available by this URL: http://localhost:45
 
 ## Deploy the Site to GitHub Pages
 
-This example describes the deployment process of our official documentation 
+This example describes the deployment process of our official documentation
 site,
-http://parallels.github.io/vagrant-parallels/docs/. You will need 
-write permissions for the GitHub repo which you want to deploy to. 
+http://parallels.github.io/vagrant-parallels/docs/. You will need
+write permissions for the GitHub repo which you want to deploy to.
 
-Make sure your current working directory is `website/docs/`. Then clone 
+Make sure your current working directory is `website/docs/`. Then clone
 "gh-pages" branch from the target repo to `./build` directory.
 ```
 $ git clone -b gh-pages https://github.com/Parallels/vagrant-parallels ./build
@@ -48,7 +48,7 @@ the repo you've cloned before:
 
 ```
 $ bundle
-$ bundle exec middleman deploy --build
+$ bundle exec middleman deploy --build-before
 ```
 
 The site should be available on GitHub: http://parallels.github.io/vagrant-parallels/docs/
@@ -58,4 +58,4 @@ The site should be available on GitHub: http://parallels.github.io/vagrant-paral
 ## Additional Links
 
 - Middleman Deploy: https://github.com/middleman-contrib/middleman-deploy
-- GitHub Pages: https://pages.github.com/ 
+- GitHub Pages: https://pages.github.com/

--- a/website/docs/source/docs/boxes/base.html.md
+++ b/website/docs/source/docs/boxes/base.html.md
@@ -55,12 +55,12 @@ with default Vagrant settings, the SSH user must be set to accept the [insecure
 keypair](https://github.com/mitchellh/vagrant/blob/master/keys/vagrant.pub)
 that ships with Vagrant.
 
-- [Parallels Tools](http://download.parallels.com/desktop/v9/ga/docs/en_US/
+- [Parallels Tools](http://download.parallels.com/desktop/v13/docs/en_US/
 Parallels%20Desktop%20User's%20Guide/32791.htm) so that things such as shared
 folders can function. There are many other benefits to installing the tools,
 such as networking configuration and device mapping.
 
-## Optimizing the Box Size
+## Box Size Optimization
 
 Prior to packaging up a box, you should shrink the hard drives as much as
 possible. This can be done with `prl_disk_tool`:

--- a/website/docs/source/docs/boxes/base.html.md
+++ b/website/docs/source/docs/boxes/base.html.md
@@ -19,7 +19,7 @@ This page documents the box format so that you can create your own base boxes
 manually.
 
 Prior to reading this page, please check out the [basics of the Vagrant
-box file format](http://docs.vagrantup.com/v2/boxes/format.html).
+box file format](https://www.vagrantup.com/docs/boxes/format.html).
 
 ## Contents
 A Parallels base box is a compressed archive of the necessary contents of
@@ -43,7 +43,7 @@ machine.
 
 There is also the "metadata.json" file used by Vagrant itself. This file
 contains nothing but the defaults which are documented on the [box format]
-(http://docs.vagrantup.com/v2/boxes/format.html) page.
+(https://www.vagrantup.com/docs/boxes/format.html) page.
 
 ## Installed Software
 

--- a/website/docs/source/docs/boxes/base.html.md
+++ b/website/docs/source/docs/boxes/base.html.md
@@ -10,7 +10,7 @@ sidebar_current: "boxes-base"
 		<strong>Warning: Advanced Topic!</strong> Creating a base box can be a
 		time consuming and tedious process, and is not recommended for new
 		Vagrant users. If you're just getting started with Vagrant, we
-		recommend trying to find <a href="https://atlas.hashicorp.com/parallels">
+		recommend trying to find <a href="https://app.vagrantup.com/parallels">
 		existing base boxes</a> to use first.
 	</p>
 </div>

--- a/website/docs/source/docs/boxes/index.html.md
+++ b/website/docs/source/docs/boxes/index.html.md
@@ -11,14 +11,15 @@ the Parallels provider has a custom box format.
 The actual list of official boxes provided by Parallels is available
 [on wiki page](https://github.com/Parallels/vagrant-parallels/wiki/Available-Vagrant-Boxes).
 
-All boxes from Parallels could be found on the ["parallels" page on Atlas](https://atlas.hashicorp.com/parallels). 
-You can also add and share your own customized boxes there. Read more on the 
-[Atlas Help](https://atlas.hashicorp.com/help) page. 
+All boxes from Parallels could be found on the ["parallels" page on Vagrant Cloud ](https://app.vagrantup.com/parallels).
+You can also create and share your own customized boxes there. Read more on the
+[Vagrant Cloud](https://www.vagrantup.com/docs/vagrant-cloud/boxes/create.html)
+documentation page.
 
 ## Discovering boxes
 
-You can also look up all community Vagrant boxes for "parallels" provider 
-and find the box matching your use case: [https://atlas.hashicorp.com/boxes/search?provider=parallels](https://atlas.hashicorp.com/boxes/search?provider=parallels)
+You can also look up all community Vagrant boxes for "parallels" provider
+and find the box matching your use case: [https://app.vagrantup.com/boxes/search?provider=parallels](https://app.vagrantup.com/boxes/search?provider=parallels)
 
 Adding a box from the catalog is very easy:
 
@@ -27,7 +28,7 @@ $ vagrant box add parallels/ubuntu-14.04
 ...
 ```
 
-You can also quickly initialize a Vagrant environment with command:
+You can also quickly initialize a Vagrant environment with the command:
 
 ```
 $ vagrant init parallels/ubuntu-14.04

--- a/website/docs/source/docs/boxes/index.html.md
+++ b/website/docs/source/docs/boxes/index.html.md
@@ -5,11 +5,11 @@ sidebar_current: "boxes"
 
 # Boxes
 
-As with [every provider](http://docs.vagrantup.com/v2/providers/basic_usage.html), 
+As with [every provider](https://www.vagrantup.com/docs/providers/basic_usage.html),
 the Parallels provider has a custom box format.
 
-The actual list of official boxes provided by Parallels is available 
-[on wiki page](https://github.com/Parallels/vagrant-parallels/wiki/Available-Vagrant-Boxes). 
+The actual list of official boxes provided by Parallels is available
+[on wiki page](https://github.com/Parallels/vagrant-parallels/wiki/Available-Vagrant-Boxes).
 
 All boxes from Parallels could be found on the ["parallels" page on Atlas](https://atlas.hashicorp.com/parallels). 
 You can also add and share your own customized boxes there. Read more on the 

--- a/website/docs/source/docs/boxes/packer.html.md
+++ b/website/docs/source/docs/boxes/packer.html.md
@@ -38,7 +38,7 @@ There are two popular projects containing Packer templates for `parallels-iso` b
 - [Bento](https://github.com/chef/bento)
 - [Boxcutter](https://github.com/boxcutter/)
 
-In Parallels we build our [official boxes](https://atlas.hashicorp.com/boxes/search?provider=parallels) 
+At Parallels we build our [official boxes](https://app.vagrantup.com/boxes/search?provider=parallels)
 using templates based on Bento project.
 
 ## Building a Box

--- a/website/docs/source/docs/boxes/packer.html.md
+++ b/website/docs/source/docs/boxes/packer.html.md
@@ -8,13 +8,13 @@ sidebar_current: "boxes-packer"
 <div class="alert alert-warn">
 	<p>
 		<strong>Warning: Advanced Topic!</strong> If you're not familiar with
-		Packer, you should read the <a href="https://packer.io/docs">
+		Packer, you should read the <a href="https://www.packer.io/docs">
 		Packer documentation</a> first.
 	</p>
 </div>
 
-Packer must be properly installed in order to build a new base box using templates. 
-Read the installation instruction here: [Install Packer](https://packer.io/docs/installation.html)
+Packer must be properly installed in order to build a new base box using templates.
+Read the installation instruction here: [Install Packer](https://www.packer.io/docs/installation.html)
 
 ## Parallels Virtualization SDK
 
@@ -53,5 +53,5 @@ Packer will done everything you need: it will download an ISO image, setup a VM,
 install Parallels Tools, make basic provisioning, and it will export the VM image
 to a `*.box` file
 
-You can read more about options which all supported template options here: 
-["parallels-iso" builder documentation](https://packer.io/docs/builders/parallels-iso.html)
+You can read more about options which all supported template options here:
+["parallels-iso" builder documentation](https://www.packer.io/docs/builders/parallels-iso.html)

--- a/website/docs/source/docs/configuration.html.md
+++ b/website/docs/source/docs/configuration.html.md
@@ -58,7 +58,7 @@ delete your boxes carefully!
 
 Parallels Tools is a set of Parallels utilities that ensures a high level of
 integration between the host and the guest operating systems (read more:
-[Parallels Tools Overview](http://download.parallels.com/desktop/v11/docs/en_US/Parallels%20Desktop%20User's%20Guide/32789.htm)).
+[Parallels Tools Overview](http://download.parallels.com/desktop/v13/docs/en_US/Parallels%20Desktop%20User's%20Guide/32789.htm)).
 
 By default the Parallels provider checks the status of Parallels Tools after
 booting the machine. If they are outdated or newer, a warning message will be
@@ -123,5 +123,5 @@ end
 ```
 
 
-You can read the [Command-Line Reference](http://download.parallels.com/desktop/v11/docs/en_US/Parallels%20Desktop%20Pro%20Edition%20Command-Line%20Reference.pdf)
+You can read the [Command-Line Reference](http://download.parallels.com/desktop/v13/docs/en_US/Parallels%20Desktop%20Pro%20Edition%20Command-Line%20Reference.pdf)
 for the complete information about the prlctl command and its options.

--- a/website/docs/source/docs/getting-started.html.md
+++ b/website/docs/source/docs/getting-started.html.md
@@ -38,7 +38,7 @@ When the virtual machine is up and running, you can log in to it via SSH:
 $ vagrant ssh
 ```
 
-You can use any of the available [vagrant commands](http://docs.vagrantup.com/v2/cli/index.html)
+You can use other [vagrant commands](https://www.vagrantup.com/docs/cli/index.html)
 to control your virtual machine.
 
 For example, you can run `vagrant halt` to gracefully shut it down, or

--- a/website/docs/source/docs/index.html.md
+++ b/website/docs/source/docs/index.html.md
@@ -35,3 +35,4 @@ It is compatible with the following versions of Parallels Desktop:
 * Parallels Desktop 10 for Mac
 * Parallels Desktop 11 for Mac - only "Pro" and "Business" editions
 * Parallels Desktop 12 for Mac - only "Pro" and "Business" editions
+* Parallels Desktop 13 for Mac - only "Pro" and "Business" editions

--- a/website/docs/source/docs/index.html.md
+++ b/website/docs/source/docs/index.html.md
@@ -10,7 +10,7 @@ the Parallels provider, which allows Vagrant to power
 virtual machines.
 
 If you're just getting started with Vagrant, it is highly recommended you start
-with the official [Vagrant documentation](http://docs.vagrantup.com/v2/).
+with the official [Vagrant documentation](https://www.vagrantup.com/docs/).
 
 
 ## What is Vagrant?

--- a/website/docs/source/docs/installation/index.html.md
+++ b/website/docs/source/docs/installation/index.html.md
@@ -6,7 +6,7 @@ sidebar_current: "installation"
 # Installing Provider
 First, make sure that you have [Parallels Desktop for Mac](http://www.parallels.com/products/desktop/)
 and [Vagrant](http://www.vagrantup.com/downloads.html) properly installed.
-We recommend that you to use the latest versions of these products.
+We recommend you using the latest versions of these products.
 
 Since the Parallels provider is a Vagrant plugin, installing it is easy:
 

--- a/website/docs/source/docs/installation/index.html.md
+++ b/website/docs/source/docs/installation/index.html.md
@@ -18,8 +18,9 @@ The Vagrant plugin installer will automatically download and install
 `vagrant-parallels` plugin.
 
 ## Requirements
-- Vagrant v1.8 or higher (_there is a known issue with Vagrant v1.9.5: 
-[GH-297](https://github.com/Parallels/vagrant-parallels/issues/297#issuecomment-304458691)_)
+- Vagrant v1.8 or higher (_there are known issues with Vagrant v1.9.5
+[[GH-297](https://github.com/Parallels/vagrant-parallels/issues/297#issuecomment-304458691)]
+and v1.9.6 [[GH-301]](https://github.com/Parallels/vagrant-parallels/issues/301)_)
 - Parallels Desktop for Mac version 10 or higher
 
 <div class="alert alert-warn">

--- a/website/docs/source/docs/installation/uninstallation.html.md
+++ b/website/docs/source/docs/installation/uninstallation.html.md
@@ -13,4 +13,4 @@ $ vagrant plugin uninstall vagrant-parallels
 ```
 
 
-*To uninstall the entire Vagrant, please refer to the [official doc page](http://docs.vagrantup.com/v2/installation/uninstallation.html)*
+*To uninstall the entire Vagrant, please refer to the [official doc page](https://www.vagrantup.com/docs/installation/uninstallation.html)*

--- a/website/docs/source/docs/networking/forwarded_ports.html.md
+++ b/website/docs/source/docs/networking/forwarded_ports.html.md
@@ -6,7 +6,7 @@ sidebar_current: "networking-fp"
 # Forwarded Ports
 
 **General Vagrant doc page**: [Forwarded Ports]
-(http://docs.vagrantup.com/v2/networking/forwarded_ports.html).
+(https://www.vagrantup.com/docs/networking/forwarded_ports.html).
 
 <div class="alert alert-info">
 	<p>

--- a/website/docs/source/docs/networking/index.html.md
+++ b/website/docs/source/docs/networking/index.html.md
@@ -6,7 +6,7 @@ sidebar_current: "networking"
 # Networking
 
 The Parallels provider supports all networking features described in the Vagrant
-[Networking](http://docs.vagrantup.com/v2/networking/basic_usage.html) documentation.
+[Networking](https://www.vagrantup.com/docs/networking/basic_usage.html) documentation.
 
 ## Basic Usage
 

--- a/website/docs/source/docs/networking/private_network.html.md
+++ b/website/docs/source/docs/networking/private_network.html.md
@@ -12,7 +12,7 @@ Private networking by the Parallels provider is fully compatible with the basic
 Vagrant approach.
 
 In order to implement a private network, the Parallels provider configures the
-internal [Host-Only](http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Desktop%20User's%20Guide/33018.htm)
+internal [Host-Only](http://download.parallels.com/desktop/v13/docs/en_US/Parallels%20Desktop%20User's%20Guide/33018.htm)
 network.
 
 ## DHCP

--- a/website/docs/source/docs/networking/private_network.html.md
+++ b/website/docs/source/docs/networking/private_network.html.md
@@ -6,7 +6,7 @@ sidebar_current: "networking-private"
 # Private Networks
 
 **General Vagrant doc page**: [Private Networks]
-(http://docs.vagrantup.com/v2/networking/private_network.html).
+(https://www.vagrantup.com/docs/networking/private_network.html).
 
 Private networking by the Parallels provider is fully compatible with the basic
 Vagrant approach.

--- a/website/docs/source/docs/networking/public_network.html.md
+++ b/website/docs/source/docs/networking/public_network.html.md
@@ -6,7 +6,7 @@ sidebar_current: "networking-public"
 # Public Networks
 
 **General Vagrant doc page**: [Public Networks]
-(http://docs.vagrantup.com/v2/networking/public_network.html).
+(https://www.vagrantup.com/docs/networking/public_network.html).
 
 Public networking by the Parallels provider is fully compatible with the basic
 Vagrant approach.

--- a/website/docs/source/docs/networking/public_network.html.md
+++ b/website/docs/source/docs/networking/public_network.html.md
@@ -12,7 +12,7 @@ Public networking by the Parallels provider is fully compatible with the basic
 Vagrant approach.
 
 In order to implement a public network, the Parallels provider configures a
-[Bridged](http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Desktop%20User's%20Guide/33015.htm)
+[Bridged](http://download.parallels.com/desktop/v13/docs/en_US/Parallels%20Desktop%20User's%20Guide/33015.htm)
 network.
 
 ## DHCP

--- a/website/docs/source/docs/share.html.md
+++ b/website/docs/source/docs/share.html.md
@@ -5,7 +5,7 @@ sidebar_current: "share"
 
 # Vagrant Share
 
-**General Vagrant doc page:** [Vagrant Share](http://docs.vagrantup.com/v2/share/index.html).
+**General Vagrant doc page:** [Vagrant Share](https://www.vagrantup.com/docs/share/index.html).
 
 Vagrant Share allows you to share your Vagrant environment with anyone in the
 world, enabling collaboration directly in your Vagrant environment in almost any
@@ -13,13 +13,13 @@ network environment with just a single command: `vagrant share`.
 
 The Parallels provider supports two primary modes or features of Vagrant Share:
 
-* [**HTTP sharing**](http://docs.vagrantup.com/v2/share/http.html) will create a
+* [**HTTP sharing**](https://www.vagrantup.com/docs/share/http.html) will create a
 URL that you can give to anyone. This URL will route directly into your Vagrant
 environment. The person using this URL does not need Vagrant installed, so it
 can be shared with anyone. This is useful for testing webhooks or showing your
 work to clients, teammates, managers, etc.
 
-* [**SSH sharing**](http://docs.vagrantup.com/v2/share/ssh.html) will allow
+* [**SSH sharing**](https://www.vagrantup.com/docs/share/ssh.html) will allow
 instant SSH access to your Vagrant environment by anyone by running `vagrant
 connect --ssh` on the remote side. This is useful for pair programming,
 debugging ops problems, etc.

--- a/website/docs/source/docs/share.html.md
+++ b/website/docs/source/docs/share.html.md
@@ -23,6 +23,3 @@ work to clients, teammates, managers, etc.
 instant SSH access to your Vagrant environment by anyone by running `vagrant
 connect --ssh` on the remote side. This is useful for pair programming,
 debugging ops problems, etc.
-
-Vagrant Share requires an account with [HashiCorp's Atlas](https://atlas.hashicorp.com/)
-to be used.

--- a/website/docs/source/docs/usage.html.md
+++ b/website/docs/source/docs/usage.html.md
@@ -6,7 +6,7 @@ sidebar_current: "usage"
 # Usage
 
 The Parallels provider is used just like any other provider. Please read the
-general [basic usage](http://docs.vagrantup.com/v2/providers/basic_usage.html)
+general [basic usage](https://www.vagrantup.com/docs/providers/basic_usage.html)
 page for providers.
 
 When Parallels provider is installed it has a higher priority than any other 


### PR DESCRIPTION
- Mention PD 13 support
- Update links to official Vagrant docs
- Update links to Parallels official docs
- Update links to Vagrant Cloud. Former Atlas, it was renamed back to Vagrant Cloud.
- Add a link to the known issue with Vagrant 1.9.6
- Update website README.md