### PR TITLE
Fix error message for host-only network collision

### DIFF
--- a/lib/vagrant-parallels/action/network.rb
+++ b/lib/vagrant-parallels/action/network.rb
@@ -291,7 +291,12 @@ module VagrantPlugins
             @env[:machine].provider.driver.read_bridged_interfaces.each do |interface|
               next if interface[:status] == 'Down'
               that_netaddr = IPAddr.new("#{interface[:ip]}/#{interface[:netmask]}")
-              raise Vagrant::Errors::NetworkCollision if netaddr.include? that_netaddr
+              if netaddr.include? that_netaddr
+                raise VagrantPlugins::Parallels::Errors::NetworkCollision,
+                  hostonly_netaddr: netaddr,
+                  bridge_netaddr:   that_netaddr,
+                  bridge_interface: interface[:name]
+              end
             end
           end
 

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -39,6 +39,10 @@ module VagrantPlugins
         error_key(:mac_os_x_required)
       end
 
+      class NetworkCollision < VagrantParallelsError
+        error_key(:network_collision)
+      end
+
       class NetworkInvalidAddress < VagrantParallelsError
         error_key(:network_invalid_address)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -58,6 +58,14 @@ en:
         which are not supported by "prl_fs" file system.
 
         Invalid mount options: %{options}
+      network_collision: |-
+        The specified host network collides with a non-hostonly network!
+        This will cause your specified IP to be inaccessible. Please change
+        the IP or name of your host only network so that it no longer matches that of
+        a bridged or non-hostonly network.
+
+        Host-only Network Address: '%{hostonly_netaddr}'
+        Bridged Network '%{bridge_interface}': '%{bridge_netaddr}'
       network_invalid_address: |-
         Network settings specified in your Vagrantfile are invalid:
 


### PR DESCRIPTION
Fixes #339 

In Vagrant v2.0.4 the exception `Vagrant::Errors::NetworkCollision` class has been modified, 2 arguments were added: https://github.com/hashicorp/vagrant/pull/9685

We port it locally here in order to keep backward compatibility with older Vagrant versions.