### PR TITLE
Changed non-script docs from HTTP to HTTPS and v14 to v16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ BREAKING CHANGES:
   Now each time when you create a new virtual machine with `vagrant up` it is
   created as a linked clone of the box image (instead of the full clone, as it
   was before). Read more about it:
-  [Full Clone vs Linked Clone](http://parallels.github.io/vagrant-parallels/docs/configuration.html#linked_clone).
+  [Full Clone vs Linked Clone](https://parallels.github.io/vagrant-parallels/docs/configuration.html#linked_clone).
   - **Dropped support of Parallels Desktop 10**. It reached
-  [End-of-Life and End-of-Support](http://kb.parallels.com/eu/122533).
+  [End-of-Life and End-of-Support](https://kb.parallels.com/eu/122533).
 
 ## 1.7.8 (November 18, 2017)
 BUG FIXES:
@@ -87,7 +87,7 @@ BUG FIXES:
 ## 1.7.0 (November 15, 2016)
 BREAKING CHANGES:
   - **Dropped support of Parallels Desktop 8 and 9**. These versions have
-  reached their [End-of-Life and End-of-Support](http://kb.parallels.com/eu/122533).
+  reached their [End-of-Life and End-of-Support](https://kb.parallels.com/eu/122533).
   - **Removed customization options, which were previously deprecated:** [[GH-271](https://github.com/Parallels/vagrant-parallels/pull/271)]
     - "use_linked_clone" - use `linked_clone` instead.
     - "regen_box_uuid" - use `regen_src_uuid` instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ $ cd vagrant-parallels
 
 ### Dependencies and Unit Tests
 
-To hack on our plugin, you'll need a [Ruby interpreter](https://www.ruby-lang.org/en/downloads/)
-(>= 2.0) and [Bundler](http://bundler.io/) which can be installed with a simple
+To hack on our plugin, you'll need a [Ruby interpreter](https://www.ruby-lang.org/en/downloads/) 
+(>= 2.0) and [Bundler](https://bundler.io/) which can be installed with a simple 
 `gem install bundler`. Afterwards, do the following:
 
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 group :plugins do
   # Specify your gem's dependencies in vagrant-parallels.gemspec

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 [![Build Status](https://travis-ci.org/Parallels/vagrant-parallels.svg?branch=master)](https://travis-ci.org/Parallels/vagrant-parallels)
 [![Code Climate](https://codeclimate.com/github/Parallels/vagrant-parallels.svg)](https://codeclimate.com/github/Parallels/vagrant-parallels)
 
-_Vagrant Parallels Provider_ is a plugin for [Vagrant](http://www.vagrantup.com),
-allowing to manage [Parallels Desktop](http://www.parallels.com/products/desktop/)
+_Vagrant Parallels Provider_ is a plugin for [Vagrant](https://www.vagrantup.com),
+allowing to manage [Parallels Desktop](https://www.parallels.com/products/desktop/)
 virtual machines on macOS hosts.
 
 ### Requirements
-- [Vagrant v1.8](http://www.vagrantup.com) or higher
+- [Vagrant v1.8](https://www.vagrantup.com) or higher
 (_there are known issues with Vagrant v1.9.5
 [[GH-297](https://github.com/Parallels/vagrant-parallels/issues/297#issuecomment-304458691)]
 and v1.9.6 [[GH-301]](https://github.com/Parallels/vagrant-parallels/issues/301)_)
-- [Parallels Desktop 11 for Mac](http://www.parallels.com/products/desktop/) or higher
+- [Parallels Desktop 11 for Mac](https://www.parallels.com/products/desktop/) or higher
 
 *Note:* Only **Pro** and **Business** editions of **Parallels Desktop for Mac**
 are compatible with this Vagrant provider.
@@ -24,11 +24,11 @@ The Parallels provider supports all basic Vagrant features, including Shared Fol
 Private and Public Networking, Forwarded ports and Vagrant Share.
 
 If you're just getting started with Vagrant, it is highly recommended that you
-read the official [Vagrant documentation](http://docs.vagrantup.com/v2/) first.
+read the official [Vagrant documentation](https://docs.vagrantup.com/v2/) first.
 
 ## Installation
-Make sure that you have [Parallels Desktop for Mac](http://www.parallels.com/products/desktop/)
-and [Vagrant](http://www.vagrantup.com/downloads.html) properly installed.
+Make sure that you have [Parallels Desktop for Mac](https://www.parallels.com/products/desktop/)
+and [Vagrant](https://www.vagrantup.com/downloads.html) properly installed.
 We recommend that you use the latest versions of these products.
 
 Parallels provider is a plugin for Vagrant. Run this command to install it:
@@ -40,12 +40,12 @@ $ vagrant plugin install vagrant-parallels
 ## Provider Documentation
 
 More information about the Parallels provider is available in
-[Vagrant Parallels Documentation](http://parallels.github.io/vagrant-parallels/docs/)
+[Vagrant Parallels Documentation](https://parallels.github.io/vagrant-parallels/docs/)
 
 We recommend you to start from these pages:
-* [Usage](http://parallels.github.io/vagrant-parallels/docs/usage.html)
-* [Getting Started](http://parallels.github.io/vagrant-parallels/docs/getting-started.html)
-* [Boxes](http://parallels.github.io/vagrant-parallels/docs/boxes/index.html)
+* [Usage](https://parallels.github.io/vagrant-parallels/docs/usage.html)
+* [Getting Started](https://parallels.github.io/vagrant-parallels/docs/getting-started.html)
+* [Boxes](https://parallels.github.io/vagrant-parallels/docs/boxes/index.html)
 
 ## Getting Help
 
@@ -58,4 +58,4 @@ please report it on the [Issue Tracker](https://github.com/Parallels/vagrant-par
 * Author: Mikhail Zholobov <legal90@gmail.com>
 * Copyright 2013-2018, Parallels International GmbH.
 
-Vagrant Parallels Provider is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).
+Vagrant Parallels Provider is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -109,12 +109,12 @@ en:
         only with Pro and Business editions of Parallels Desktop. Other editions
         do not have command line functionality and can not be used with Vagrant.
 
-        Please upgrade your installation: http://parallels.com/desktop
+        Please upgrade your installation: https://parallels.com/desktop
       parallels_unsupported_version: |-
         Vagrant has detected that you have a version of Parallels Desktop for Mac
         installed that is not supported. Vagrant Parallels provider is compatible
         only with Parallels Desktop 11 or later.
-        Please upgrade your installation: http://parallels.com/desktop
+        Please upgrade your installation: https://parallels.com/desktop
 
         Note: Starting since Parallels Desktop 11 for Mac, Vagrant Parallels
         provider can be only used with Pro or Business edition of Parallels

--- a/vagrant-parallels.gemspec
+++ b/vagrant-parallels.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['mzholobov@parallels.com', 'yshahin@gmail.com']
   spec.summary       = %q{Parallels provider for Vagrant.}
   spec.description   = %q{Enables Vagrant to manage Parallels virtual machines.}
-  spec.homepage      = 'http://github.com/Parallels/vagrant-parallels'
+  spec.homepage      = 'https://github.com/Parallels/vagrant-parallels'
   spec.license       = 'MIT'
 
   spec.required_rubygems_version = '>= 1.3.6'

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -3,7 +3,7 @@
 There are sources for documentation pages:
 http://parallels.github.io/vagrant-parallels/docs/
 
-This is a [Middleman](http://middlemanapp.com) project, which builds a static
+This is a [Middleman](https://middlemanapp.com) project, which builds a static
 site from these source files.
 
 ## Contributions Welcome!
@@ -51,8 +51,8 @@ $ bundle
 $ bundle exec middleman deploy --build-before
 ```
 
-The site should be available on GitHub: http://parallels.github.io/vagrant-parallels/docs/
-(or `http://<YOUR_USER>.github.io/vagrant-parallels/docs/`)
+The site should be available on GitHub: https://parallels.github.io/vagrant-parallels/docs/
+(or `https://<YOUR_USER>.github.io/vagrant-parallels/docs/`)
 
 
 ## Additional Links

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -1,7 +1,7 @@
 # Vagrant Parallels Documentation
 
 There are sources for documentation pages:
-http://parallels.github.io/vagrant-parallels/docs/
+https://parallels.github.io/vagrant-parallels/docs/
 
 This is a [Middleman](https://middlemanapp.com) project, which builds a static
 site from these source files.
@@ -29,7 +29,7 @@ Your local copy of the site should be available by this URL: http://localhost:45
 
 This example describes the deployment process of our official documentation
 site,
-http://parallels.github.io/vagrant-parallels/docs/. You will need
+https://parallels.github.io/vagrant-parallels/docs/. You will need
 write permissions for the GitHub repo which you want to deploy to.
 
 Make sure your current working directory is `website/docs/`. Then clone

--- a/website/docs/source/docs/boxes/base.html.md
+++ b/website/docs/source/docs/boxes/base.html.md
@@ -58,8 +58,7 @@ with default Vagrant settings, the SSH user must be set to accept the [insecure
 keypair](https://github.com/mitchellh/vagrant/blob/master/keys/vagrant.pub)
 that ships with Vagrant.
 
-- [Parallels Tools](https://download.parallels.com/desktop/v14/docs/en_US/
-Parallels%20Desktop%20User's%20Guide/32791.htm) so that things such as shared
+- [Parallels Tools](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Desktop%20User's%20Guide/32791.htm) so that things such as shared
 folders can function. There are many other benefits to installing the tools,
 such as networking configuration and device mapping.
 

--- a/website/docs/source/docs/boxes/base.html.md
+++ b/website/docs/source/docs/boxes/base.html.md
@@ -58,7 +58,7 @@ with default Vagrant settings, the SSH user must be set to accept the [insecure
 keypair](https://github.com/mitchellh/vagrant/blob/master/keys/vagrant.pub)
 that ships with Vagrant.
 
-- [Parallels Tools](http://download.parallels.com/desktop/v14/docs/en_US/
+- [Parallels Tools](https://download.parallels.com/desktop/v14/docs/en_US/
 Parallels%20Desktop%20User's%20Guide/32791.htm) so that things such as shared
 folders can function. There are many other benefits to installing the tools,
 such as networking configuration and device mapping.

--- a/website/docs/source/docs/boxes/packer.html.md
+++ b/website/docs/source/docs/boxes/packer.html.md
@@ -21,7 +21,7 @@ Read the installation instruction here: [Install Packer](https://www.packer.io/d
 Packer requires the 'prlsdkapi' Python module from the Parallels Virtualization
 SDK to interact with Parallels Desktop and virtual machines. To use Parallels
 builders for Packer you need to download and install this SDK package:
-[The Parallels Virtualization SDK for Mac](http://www.parallels.com/download/pvsdk/)
+[The Parallels Virtualization SDK for Mac](https://www.parallels.com/download/pvsdk/)
 
 You can also install it with [Homebrew](brew.sh) package manager:
 

--- a/website/docs/source/docs/boxes/veewee.html.md
+++ b/website/docs/source/docs/boxes/veewee.html.md
@@ -23,7 +23,7 @@ instructions.
 Veewee requires the 'prlsdkapi' Python module from the Parallels Virtualization
 SDK to interact with Parallels Desktop and virtual machines. To use Veewee with
 the Parallels provider you need to download and install this SDK package:
-[The Parallels Virtualization SDK for Mac](http://www.parallels.com/download/pvsdk/)
+[The Parallels Virtualization SDK for Mac](https://www.parallels.com/download/pvsdk/)
 
 You can also install it with [Homebrew](brew.sh) package manager:
 

--- a/website/docs/source/docs/configuration.html.md
+++ b/website/docs/source/docs/configuration.html.md
@@ -56,7 +56,7 @@ _Note:_ Changes of this setting will take an effect only for newly created machi
 
 Parallels Tools is a set of Parallels utilities that ensures a high level of
 integration between the host and the guest operating systems (read more:
-[Parallels Tools Overview](http://download.parallels.com/desktop/v14/docs/en_US/Parallels%20Desktop%20User's%20Guide/32789.htm)).
+[Parallels Tools Overview](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Desktop%20User's%20Guide/32789.htm)).
 
 By default the Parallels provider checks the status of Parallels Tools after
 booting the machine. If they are outdated or newer, a warning message will be
@@ -121,5 +121,5 @@ end
 ```
 
 
-You can read the [Command-Line Reference](http://download.parallels.com/desktop/v14/docs/en_US/Parallels%20Desktop%20Pro%20Edition%20Command-Line%20Reference.pdf)
+You can read the [Command-Line Reference](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Desktop%20Pro%20Edition%20Command-Line%20Reference.pdf)
 for the complete information about the prlctl command and its options.

--- a/website/docs/source/docs/contacts.html.md
+++ b/website/docs/source/docs/contacts.html.md
@@ -5,7 +5,7 @@ sidebar_current: "contacts"
 
 # Contacts
 
-- Official Forum: [Parallels Forum](http://forum.parallels.com/forumdisplay.php?737)
+- Official Forum: [Parallels Forum](https://forum.parallels.com/forumdisplay.php?737)
 
 - Issue Tracker: [GitHub Issues](https://github.com/Parallels/vagrant-parallels/issues)
 

--- a/website/docs/source/docs/getting-started.html.md
+++ b/website/docs/source/docs/getting-started.html.md
@@ -8,7 +8,7 @@ sidebar_current: "gettingstarted"
 This page describes steps to get your first Parallels Desktop virtual machine
 managed by Vagrant.
 
-First, download and install [Vagrant for Mac](http://www.vagrantup.com/downloads.html).
+First, download and install [Vagrant for Mac](https://www.vagrantup.com/downloads.html).
 Second, install the 'vagrant-parallels' plugin:
 
 ```

--- a/website/docs/source/docs/index.html.md
+++ b/website/docs/source/docs/index.html.md
@@ -6,7 +6,7 @@ sidebar_current: "overview"
 
 Welcome to the Parallels provider for Vagrant documentation! This site documents
 the Parallels provider, which allows Vagrant to power
-[Parallels Desktop for Mac](http://www.parallels.com/products/desktop/) based
+[Parallels Desktop for Mac](https://www.parallels.com/products/desktop/) based
 virtual machines.
 
 If you're just getting started with Vagrant, it is highly recommended you start
@@ -24,8 +24,8 @@ Vagrant ships out of the box with support for VirtualBox and HyperV only.
 ## What is Parallels Provider?
 
 The Parallels provider for Vagrant is a plugin officially supported by
-[Parallels](http://www.parallels.com/). This Vagrant plugin allows to manage
-[Parallels Desktop for Mac](http://www.parallels.com/products/desktop/) based
+[Parallels](https://www.parallels.com/). This Vagrant plugin allows to manage
+[Parallels Desktop for Mac](https://www.parallels.com/products/desktop/) based
 virtual machines and take advantage of the world's bestselling, top-rated, and
 most trusted solution for running virtual machines on macOS.
 

--- a/website/docs/source/docs/installation/index.html.md
+++ b/website/docs/source/docs/installation/index.html.md
@@ -4,8 +4,8 @@ sidebar_current: "installation"
 ---
 
 # Installing Provider
-First, make sure that you have [Parallels Desktop for Mac](http://www.parallels.com/products/desktop/)
-and [Vagrant](http://www.vagrantup.com/downloads.html) properly installed.
+First, make sure that you have [Parallels Desktop for Mac](https://www.parallels.com/products/desktop/)
+and [Vagrant](https://www.vagrantup.com/downloads.html) properly installed.
 We recommend you using the latest versions of these products.
 
 Since the Parallels provider is a Vagrant plugin, installing it is easy:

--- a/website/docs/source/docs/networking/private_network.html.md
+++ b/website/docs/source/docs/networking/private_network.html.md
@@ -12,7 +12,7 @@ Private networking by the Parallels provider is fully compatible with the basic
 Vagrant approach.
 
 In order to implement a private network, the Parallels provider configures the
-internal [Host-Only](http://download.parallels.com/desktop/v14/docs/en_US/Parallels%20Desktop%20User's%20Guide/33018.htm)
+internal [Host-Only](https://download.parallels.com/desktop/v14/docs/en_US/Parallels%20Desktop%20User's%20Guide/33018.htm)
 network.
 
 ## DHCP
@@ -47,6 +47,6 @@ It is a responsibility of the user to ensure that the static IP address does not
 conflict with any other machines on the same network.
 
 While you can choose any IP address, you _should_ use an IP from the
-[reserved private address space](http://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces).
+[reserved private address space](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces).
 These addresses are guaranteed to never be publicly routable, and most routers
 actually block traffic from going to them from the outside world.

--- a/website/docs/source/docs/networking/private_network.html.md
+++ b/website/docs/source/docs/networking/private_network.html.md
@@ -12,7 +12,7 @@ Private networking by the Parallels provider is fully compatible with the basic
 Vagrant approach.
 
 In order to implement a private network, the Parallels provider configures the
-internal [Host-Only](https://download.parallels.com/desktop/v14/docs/en_US/Parallels%20Desktop%20User's%20Guide/33018.htm)
+internal [Host-Only](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Desktop%20User's%20Guide/33018.htm)
 network.
 
 ## DHCP

--- a/website/docs/source/docs/networking/public_network.html.md
+++ b/website/docs/source/docs/networking/public_network.html.md
@@ -12,7 +12,7 @@ Public networking by the Parallels provider is fully compatible with the basic
 Vagrant approach.
 
 In order to implement a public network, the Parallels provider configures a
-[Bridged](http://download.parallels.com/desktop/v14/docs/en_US/Parallels%20Desktop%20User's%20Guide/33015.htm)
+[Bridged](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Desktop%20User's%20Guide/33015.htm)
 network.
 
 ## DHCP


### PR DESCRIPTION
I noticed the latest Parallels documentation is v15 but the site has v14 links, and trying to load the non-existent v16 redirects to the current v15, so I kept v16 because I assume it will remain up-to-date for longer.

Since I'm updating links anyway, I thought I might as well change them (and test the links) to HTTPS, too. I did not update scripts because I haven't tested if they still work.