### PR TITLE
Update gem dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,19 +10,19 @@ $ cd vagrant-parallels
 
 ### Dependencies and Unit Tests
 
-To hack on our plugin, you'll need a [Ruby interpreter](https://www.ruby-lang.org/en/downloads/) 
-(>= 2.0) and [Bundler](http://bundler.io/) which can be installed with a simple 
+To hack on our plugin, you'll need a [Ruby interpreter](https://www.ruby-lang.org/en/downloads/)
+(>= 2.0) and [Bundler](http://bundler.io/) which can be installed with a simple
 `gem install bundler`. Afterwards, do the following:
 
 ```
 $ bundle install
-$ rake
+$ bundle exec rake
 ```
 
-This will run the unit test suite, which should come back all green! 
+This will run the unit test suite, which should come back all green!
 Then you're good to go!
 
-If you want to run Vagrant without having to install the `vagrant-parallels` 
+If you want to run Vagrant without having to install the `vagrant-parallels`
 gem, you may use `bundle exec`, like so:
 
 ```
@@ -33,7 +33,7 @@ $ bundle exec vagrant up --provider=parallels
 To build a `vagrant-parallels` gem just run this command:
 
 ```
-$ rake build
+$ bundle exec rake build
 ```
 
 The built "gem" package will appear in the `./pkg` folder.
@@ -75,6 +75,6 @@ specify a local path to it.
 Run acceptance tests:
 
 ```
-$ rake acceptance:run
+$ bundle exec rake acceptance:run
 ...
 ```

--- a/vagrant-parallels.gemspec
+++ b/vagrant-parallels.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   # Constraint rake to properly handle deprecated method usage
   # from within rspec
-  spec.add_development_dependency 'rake', '~> 11.3.0'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.5.0'
-  spec.add_development_dependency 'rspec-its', '~> 1.2.0'
+  spec.add_development_dependency 'rspec-its', '~> 1.3.0'
 
   spec.files = Dir['lib/**/*', 'locales/**/*', 'README.md', 'CHANGELOG.md', 'LICENSE.txt']
   spec.require_path = 'lib'


### PR DESCRIPTION
This PR updates gem dependencies, such as `rake`, as suggested by the GitHub security alert.

Also, I updated the CONTRIBUTING.md guidelines by adding `bundle exec`, assuming that `rake` from our `Gemfile` is used.