### PR TITLE
Use host_inodes flag when mounting shared folders

### DIFF
--- a/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
@@ -35,12 +35,12 @@ module VagrantPlugins
           end
 
           # First mount command uses getent to get the group
-          mount_options = "-o uid=#{mount_uid},gid=#{mount_gid}"
+          mount_options = "-o uid=#{mount_uid},gid=#{mount_gid},host_inodes"
           mount_options += ",#{options[:mount_options].join(',')}" if options[:mount_options]
           mount_commands << "mount -t prl_fs #{mount_options} #{name} #{expanded_guest_path}"
 
           # Second mount command uses the old style `id -g`
-          mount_options = "-o uid=#{mount_uid},gid=#{mount_gid_old}"
+          mount_options = "-o uid=#{mount_uid},gid=#{mount_gid_old},host_inodes"
           mount_options += ",#{options[:mount_options].join(',')}" if options[:mount_options]
           mount_commands << "mount -t prl_fs #{mount_options} #{name} #{expanded_guest_path}"
 


### PR DESCRIPTION
After updating to Parallels 16 and the corresponding Parallels Tools in the guest VM, we experienced the following problem with the `install` command in shared folders with the `prl_fs`:

```
$ install foo bar
install: skipping file 'foo', as it was replaced while being copied
```

This seems to be same issue as described in https://forum.parallels.com/threads/cannot-move-file-in-shared-folder-after-upgrade-to-pd16.350648/ , at least we were able to solve it by passing the host_inodes flag as a mount option in our Vagrantfile:

```diff
-  config.vm.synced_folder "~/Projekte", "/var/www", mount_options: ["share", "noatime"]
+  config.vm.synced_folder "~/Projekte", "/var/www", mount_options: ["share", "noatime", "host_inodes"]
```

This PR suggests to make this a default mount option.

/cc @mpdude