### PR TITLE
Update vagrant-spec branch name in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ group :development do
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git'
-  gem 'vagrant-spec', git: 'https://github.com/mitchellh/vagrant-spec.git'
+  gem 'vagrant-spec', git: 'https://github.com/mitchellh/vagrant-spec.git', branch: 'main'
 end


### PR DESCRIPTION
Default branch name has changed to `main`
