### PR TITLE
chore: update gemfile dependency to point at correct repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git'
-  gem 'vagrant-spec', git: 'https://github.com/mitchellh/vagrant-spec.git', branch: 'main'
+  gem 'vagrant', git: 'https://github.com/hashicorp/vagrant.git'
+  gem 'vagrant-spec', git: 'https://github.com/hashicorp/vagrant-spec.git', branch: 'main'
 end


### PR DESCRIPTION
Looks like vagrant has moved from mitchelh to vagrant. Updates the gemfile to reflect this.