### PR TITLE
fix: broken custom vagrantfile support

### DIFF
--- a/lib/vagrant-parallels/action.rb
+++ b/lib/vagrant-parallels/action.rb
@@ -113,6 +113,7 @@ module VagrantPlugins
             b1.use Package
             b1.use Export
             b1.use PackageConfigFiles
+            b1.use PackageVagrantfile
           end
         end
       end
@@ -413,6 +414,7 @@ module VagrantPlugins
       autoload :Network, File.expand_path('../action/network', __FILE__)
       autoload :Package, File.expand_path('../action/package', __FILE__)
       autoload :PackageConfigFiles, File.expand_path('../action/package_config_files', __FILE__)
+      autoload :PackageVagrantfile, File.expand_path('../action/package_vagrantfile', __FILE__)
       autoload :PrepareCloneSnapshot, File.expand_path('../action/prepare_clone_snapshot', __FILE__)
       autoload :PrepareForwardedPortCollisionParams, File.expand_path('../action/prepare_forwarded_port_collision_params', __FILE__)
       autoload :PrepareNFSSettings, File.expand_path('../action/prepare_nfs_settings', __FILE__)

--- a/lib/vagrant-parallels/action/package_vagrantfile.rb
+++ b/lib/vagrant-parallels/action/package_vagrantfile.rb
@@ -1,0 +1,33 @@
+require 'vagrant/util/template_renderer'
+
+module VagrantPlugins
+  module Parallels
+    module Action
+      class PackageVagrantfile
+        # For TemplateRenderer
+        include Vagrant::Util
+
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          @env = env
+          create_vagrantfile
+          @app.call(env)
+        end
+
+        # This method creates the auto-generated Vagrantfile at the root of the
+        # box. This Vagrantfile contains the MAC address so that the user doesn't
+        # have to worry about it.
+        def create_vagrantfile
+          File.open(File.join(@env["export.temp_dir"], "Vagrantfile"), "w") do |f|
+            f.write(TemplateRenderer.render("package_Vagrantfile", {
+              base_mac: @env[:machine].provider.driver.read_mac_address
+            }))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently `vagrant package --vagrantfile myvagrantfile` is broken. 

It copies the custom vagrant to the box archive, however the custom vagrantfile `includes/_Vagrantfile` is never loaded by the actual vagrantfile `./vagrantfile`

This PR adds the package_vagrantfile action (stolen from the virtualbox provider). 

This means that the following template will be rendered:

https://github.com/hashicorp/vagrant/blob/6e670777aff01043b7c21e60dd2ce95b5e433806/templates/package_Vagrantfile.erb#L10

Causing the custom vagrantfile that is already copied to actually be referenced and to work.