### PR TITLE
Fix the concurrency issue with box un-register in multi-vm environment

### DIFF
--- a/lib/vagrant-parallels/action/box_unregister.rb
+++ b/lib/vagrant-parallels/action/box_unregister.rb
@@ -53,9 +53,9 @@ module VagrantPlugins
             file.flush
           end
 
-          # Delete the lease file if we are the last who need this box.
+          # Delete the lease file if we were the last who needed this box.
           # Then the box image will be unregistered.
-          lease_file.delete if lease_file.read.chomp.to_i <= 1
+          lease_file.delete if lease_file.read.chomp.to_i <= 0
         end
 
         def unregister_box(env)


### PR DESCRIPTION
Fixes https://github.com/Parallels/vagrant-parallels/issues/357

This PR fixes the concurrency issue of box un-register when running in multi-vm environment.

There was a sad mistake in this file. If we start the lease counter with 0, we should obviously expect to get back to 0 when the last VM cloning the the box is ready to release it.

