### PR TITLE
Do not  expect "Bound To" field to be present in "prlsrvctl net info"

### DIFF
--- a/test/unit/action/network_test.rb
+++ b/test/unit/action/network_test.rb
@@ -131,7 +131,6 @@ describe VagrantPlugins::Parallels::Action::Network do
         let(:hostonlyifs) {
           [{
              name:     'vagrant-vnet2',
-             bound_to: 'vnic4',
              ip:       '172.28.128.2',
              netmask:  '255.255.255.0',
              status:   'Up'

--- a/test/unit/support/shared/parallels_context.rb
+++ b/test/unit/support/shared/parallels_context.rb
@@ -10,7 +10,6 @@ shared_context 'parallels' do
   let(:tpl_name) {'Some_Template_Name'}
   let(:tools_state) {'installed'}
   let(:tools_version) {'12.0.18615.123456'}
-  let(:hostonly_iface) {'vnic10'}
 
   let(:vnic_options) do {
     name:       'vagrant_vnic6',
@@ -179,7 +178,6 @@ shared_context 'parallels' do
 {
   "Network ID": "#{vnic_options[:name]}",
   "Type": "host-only",
-  "Bound To": "#{hostonly_iface}",
   "Parallels adapter": {
     "IP address": "#{vnic_options[:adapter_ip]}",
     "Subnet mask": "#{vnic_options[:netmask]}"


### PR DESCRIPTION
Fixes https://github.com/Parallels/vagrant-parallels/issues/369

The field `Bound To` is not printed anymore in the output of `prlsrvctl net info` on macOS 11.0+, so we shouldn't rely on it.
