### PR TITLE
Implement "mount_options" and "mount_type" capabilities, persisting shared folders after manual reboot

### DIFF
--- a/lib/vagrant-parallels/cap/mount_options.rb
+++ b/lib/vagrant-parallels/cap/mount_options.rb
@@ -29,6 +29,10 @@ module VagrantPlugins
         def self.mount_type(machine)
           return PRL_MOUNT_TYPE
         end
+
+        def self.mount_name(machine, data)
+          data[:guestpath].gsub(/[*":<>?|\/\\]/,'_').sub(/^_/, '')
+        end
       end
     end
   end

--- a/lib/vagrant-parallels/cap/mount_options.rb
+++ b/lib/vagrant-parallels/cap/mount_options.rb
@@ -1,0 +1,35 @@
+require_relative "../util/unix_mount_helpers"
+
+module VagrantPlugins
+  module Parallels
+    module SyncedFolderCap
+      module MountOptions
+        extend VagrantPlugins::Parallels::Util::UnixMountHelpers
+
+        PRL_MOUNT_TYPE = "prl_fs".freeze
+
+        # Returns mount options for a parallels synced folder
+        #
+        # @param [Machine] machine
+        # @param [String] name of mount
+        # @param [String] path of mount on guest
+        # @param [Hash] hash of mount options
+        def self.mount_options(machine, name, guest_path, options)
+          mount_options = options.fetch(:mount_options, [])
+          detected_ids = detect_owner_group_ids(machine, guest_path, mount_options, options)
+          mount_uid = detected_ids[:uid]
+          mount_gid = detected_ids[:gid]
+
+          mount_options << "uid=#{mount_uid}"
+          mount_options << "gid=#{mount_gid}"
+          mount_options = mount_options.join(',')
+          return mount_options, mount_uid, mount_gid
+        end
+
+        def self.mount_type(machine)
+          return PRL_MOUNT_TYPE
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/errors.rb
+++ b/lib/vagrant-parallels/errors.rb
@@ -27,10 +27,6 @@ module VagrantPlugins
         error_key(:json_parse_error)
       end
 
-      class LinuxMountFailed < VagrantParallelsError
-        error_key(:linux_mount_failed)
-      end
-
       class LinuxPrlFsInvalidOptions < VagrantParallelsError
         error_key(:linux_prl_fs_invalid_options)
       end
@@ -57,6 +53,10 @@ module VagrantPlugins
 
       class ParallelsInvalidVersion < VagrantParallelsError
         error_key(:parallels_invalid_version)
+      end
+
+      class ParallelsMountFailed < VagrantParallelsError
+        error_key(:parallels_mount_failed)
       end
 
       class ParallelsNotDetected < VagrantParallelsError

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -103,6 +103,16 @@ module VagrantPlugins
         SyncedFolder
       end
 
+      synced_folder_capability(:parallels, "mount_options") do
+        require_relative "cap/mount_options"
+        SyncedFolderCap::MountOptions
+      end
+
+      synced_folder_capability(:parallels, "mount_type") do
+        require_relative "cap/mount_options"
+        SyncedFolderCap::MountOptions
+      end
+
       # This initializes the internationalization strings.
       def self.setup_i18n
         I18n.load_path << File.expand_path('locales/en.yml', Parallels.source_root)

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -103,6 +103,11 @@ module VagrantPlugins
         SyncedFolder
       end
 
+      synced_folder_capability(:parallels, "mount_name") do
+        require_relative "cap/mount_options"
+        SyncedFolderCap::MountOptions
+      end
+
       synced_folder_capability(:parallels, "mount_options") do
         require_relative "cap/mount_options"
         SyncedFolderCap::MountOptions

--- a/lib/vagrant-parallels/synced_folder.rb
+++ b/lib/vagrant-parallels/synced_folder.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
           end
 
           defs << {
-            name: os_friendly_id(id),
+            name: data[:plugin].capability(:mount_name, data),
             hostpath: hostpath.to_s,
           }
         end
@@ -89,7 +89,7 @@ module VagrantPlugins
         end
 
         # Remove the shared folders from the VM metadata
-        names = folders.map { |id, _data| os_friendly_id(id) }
+        names = folders.map { |_id, data| data[:plugin].capability(:mount_name, data) }
         driver(machine).unshare_folders(names)
       end
 
@@ -102,11 +102,6 @@ module VagrantPlugins
       # This is here so that we can stub it for tests
       def driver(machine)
         machine.provider.driver
-      end
-
-      def os_friendly_id(id)
-        # Replace chars *, ", :, <, >, ?, |, /, \
-        id.gsub(/[*":<>?|\/\\]/,'_').sub(/^_/, '')
       end
     end
   end

--- a/lib/vagrant-parallels/util/unix_mount_helpers.rb
+++ b/lib/vagrant-parallels/util/unix_mount_helpers.rb
@@ -1,0 +1,121 @@
+require "shellwords"
+require "vagrant/util/retryable"
+
+module VagrantPlugins
+  module Parallels
+    module Util
+      module UnixMountHelpers
+
+        def self.extended(klass)
+          if !klass.class_variable_defined?(:@@logger)
+            klass.class_variable_set(:@@logger, Log4r::Logger.new(klass.name.downcase))
+          end
+          klass.extend Vagrant::Util::Retryable
+        end
+
+        def detect_owner_group_ids(machine, guest_path, mount_options, options)
+          mount_uid = find_mount_options_id("uid", mount_options)
+          mount_gid = find_mount_options_id("gid", mount_options)
+
+          if mount_uid.nil?
+            if options[:owner].to_i.to_s == options[:owner].to_s
+              mount_uid = options[:owner]
+              self.class_variable_get(:@@logger).debug("Owner user ID (provided): #{mount_uid}")
+            else
+              output = {stdout: '', stderr: ''}
+              uid_command = "id -u #{options[:owner]}"
+              machine.communicate.execute(uid_command,
+                error_class: Errors::ParallelsMountFailed,
+                error_key: :parallels_mount_failed,
+                command: uid_command,
+                output: output[:stderr]
+              ) { |type, data| output[type] << data if output[type] }
+              mount_uid = output[:stdout].chomp
+              self.class_variable_get(:@@logger).debug("Owner user ID (lookup): #{options[:owner]} -> #{mount_uid}")
+            end
+          else
+            machine.ui.warn "Detected mount owner ID within mount options. (uid: #{mount_uid} guestpath: #{guest_path})"
+          end
+
+          if mount_gid.nil?
+            if options[:group].to_i.to_s == options[:group].to_s
+              mount_gid = options[:group]
+              self.class_variable_get(:@@logger).debug("Owner group ID (provided): #{mount_gid}")
+            else
+              begin
+                output = {stdout: '', stderr: ''}
+                gid_command = "getent group #{options[:group]}"
+                machine.communicate.execute(gid_command,
+                  error_class: Errors::ParallelsMountFailed,
+                  error_key: :parallels_mount_failed,
+                  command: gid_command,
+                  output: output[:stderr]
+                ) { |type, data| output[type] << data if output[type] }
+                mount_gid = output[:stdout].split(':').at(2).to_s.chomp
+                self.class_variable_get(:@@logger).debug("Owner group ID (lookup): #{options[:group]} -> #{mount_gid}")
+              rescue Vagrant::Errors::ParallelsMountFailed
+                if options[:owner] == options[:group]
+                  self.class_variable_get(:@@logger).debug("Failed to locate group `#{options[:group]}`. Group name matches owner. Fetching effective group ID.")
+                  output = {stdout: ''}
+                  result = machine.communicate.execute("id -g #{options[:owner]}",
+                    error_check: false
+                  ) { |type, data| output[type] << data if output[type] }
+                  mount_gid = output[:stdout].chomp if result == 0
+                  self.class_variable_get(:@@logger).debug("Owner group ID (effective): #{mount_gid}")
+                end
+                raise unless mount_gid
+              end
+            end
+          else
+            machine.ui.warn "Detected mount group ID within mount options. (gid: #{mount_gid} guestpath: #{guest_path})"
+          end
+          {:gid => mount_gid, :uid => mount_uid}
+        end
+
+        def find_mount_options_id(id_name, mount_options)
+          id_line = mount_options.detect{|line| line.include?("#{id_name}=")}
+          if id_line
+            match = id_line.match(/,?#{Regexp.escape(id_name)}=(?<option_id>\d+),?/)
+            found_id = match["option_id"]
+            updated_id_line = [
+              match.pre_match,
+              match.post_match
+            ].find_all{|string| !string.empty?}.join(',')
+            if updated_id_line.empty?
+              mount_options.delete(id_line)
+            else
+              idx = mount_options.index(id_line)
+              mount_options.delete(idx)
+              mount_options.insert(idx, updated_id_line)
+            end
+          end
+          found_id
+        end
+
+        def emit_upstart_notification(machine, guest_path)
+          # Emit an upstart event if we can
+          machine.communicate.sudo <<-EOH.gsub(/^ {12}/, "")
+              if command -v /sbin/init && /sbin/init 2>/dev/null --version | grep upstart; then
+                /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guest_path}
+              fi
+            EOH
+        end
+
+        def merge_mount_options(base, overrides)
+          base = base.join(",").split(",")
+          overrides = overrides.join(",").split(",")
+          b_kv = Hash[base.map{|item| item.split("=", 2) }]
+          o_kv = Hash[overrides.map{|item| item.split("=", 2) }]
+          merged = {}.tap do |opts|
+            (b_kv.keys + o_kv.keys).uniq.each do |key|
+              opts[key] = o_kv.fetch(key, b_kv[key])
+            end
+          end
+          merged.map do |key, value|
+            [key, value].compact.join("=")
+          end
+        end
+      end
+    end
+  end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -45,14 +45,6 @@ en:
         disk is inconsistent, please remove it from the VM configuration.
 
         Disk image path: %{path}
-      linux_mount_failed: |-
-        Failed to mount folders in Linux guest. This is usually because
-        the "prl_fs" file system is not available. Please verify that
-        Parallels Tools are properly installed in the guest and
-        can work properly. If so, the VM reboot can solve a problem.
-        The command attempted was:
-
-        %{command}
       linux_prl_fs_invalid_options: |-
         Failed to mount folders in Linux guest. You've specified mount options
         which are not supported by "prl_fs" file system.
@@ -81,6 +73,19 @@ en:
           %{output}
 
         This is an internal error that should be reported as a bug.
+      parallels_mount_failed: |-
+        Vagrant was unable to mount Parallels Desktop shared folders. This is usually
+        because the filesystem "prl_fs" is not available. This filesystem is
+        made available via the Parallels Tools and kernel module.
+        Please verify that these guest tools are properly installed in the
+        guest. This is not a bug in Vagrant and is usually caused by a faulty
+        Vagrant box. For context, the command attempted was:
+
+        %{command}
+
+        The error output from the command was:
+
+        %{output}
       parallels_no_room_for_high_level_network: |-
         There is no available slots on the Parallels Desktop VM for the configured
         high-level network interfaces. "private_network" and "public_network"


### PR DESCRIPTION
This PR ports the functionality "Persist Shared Folders after manual reboot" for Linux gusest, which has been recently implemented in upstream Vagrant :
- https://github.com/hashicorp/vagrant/pull/11570
- https://github.com/hashicorp/vagrant/pull/11797

Now shared folder mounts are added to `/etc/fstab` on the guest side, so the they will be properly re-mounted after a "manual" reboot of the VM.

Fixes #376
Fixes #290 