### PR TITLE
[cap/mount_options] Fix "mount_name" compatibility with Vagrant 2.2.15+

### DIFF
--- a/lib/vagrant-parallels/cap/mount_options.rb
+++ b/lib/vagrant-parallels/cap/mount_options.rb
@@ -30,8 +30,18 @@ module VagrantPlugins
           return PRL_MOUNT_TYPE
         end
 
-        def self.mount_name(machine, data)
-          data[:guestpath].gsub(/[*":<>?|\/\\]/,'_').sub(/^_/, '')
+        ## We have to support 2 different expected interfaces of `mount_name` call:
+        ##   Vagrant < 2.2.15:   `def self.mount_name(machine, data)`
+        ##   Vagrant >= 2.2.15:  `def self.mount_name(machine, id, data)`
+        ## https://github.com/Parallels/vagrant-parallels/issues/384
+        def self.mount_name(*args)
+          if args.length >= 3
+            id = args[1]
+          else
+            id = args[-1][:guestpath]
+          end
+
+          id.gsub(/[*":<>?|\/\\]/,'_').sub(/^_/, '')
         end
       end
     end

--- a/lib/vagrant-parallels/synced_folder.rb
+++ b/lib/vagrant-parallels/synced_folder.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
           end
 
           defs << {
-            name: data[:plugin].capability(:mount_name, data),
+            name: data[:plugin].capability(:mount_name, id, data),
             hostpath: hostpath.to_s,
           }
         end
@@ -62,7 +62,7 @@ module VagrantPlugins
             # Mount the actual folder
             machine.guest.capability(
               :mount_parallels_shared_folder,
-              data[:plugin].capability(:mount_name, data),
+              data[:plugin].capability(:mount_name, id, data),
               data[:guestpath],
               data
             )
@@ -84,7 +84,7 @@ module VagrantPlugins
         end
 
         # Remove the shared folders from the VM metadata
-        names = folders.map { |_id, data| data[:plugin].capability(:mount_name, data) }
+        names = folders.map { |id, data| data[:plugin].capability(:mount_name, id, data) }
         driver(machine).unshare_folders(names)
       end
 


### PR DESCRIPTION
Fixes https://github.com/Parallels/vagrant-parallels/issues/384

Vagrant 2.2.15 includes hashicorp/vagrant#12184 which apparently changes the expected interface of `mount_name` synced folder capability. It seems that Vagrant maintainers didn't consider that there could be other plugins implementing this capability on their side :(

As the result, in order to keep the backward compatibility with older versions of Vagrant we have to do a dirty hack with `mount_name` implementation, assuming that it could be called with 2 or 3 positional arguments.