### PR TITLE
Fix shared folder mount on the VM reboot

### DIFF
--- a/lib/vagrant-parallels/cap/mount_options.rb
+++ b/lib/vagrant-parallels/cap/mount_options.rb
@@ -22,6 +22,7 @@ module VagrantPlugins
 
           mount_options << "uid=#{mount_uid}"
           mount_options << "gid=#{mount_gid}"
+          mount_options << "_netdev"
           mount_options = mount_options.join(',')
           return mount_options, mount_uid, mount_gid
         end

--- a/lib/vagrant-parallels/synced_folder.rb
+++ b/lib/vagrant-parallels/synced_folder.rb
@@ -9,8 +9,8 @@ module VagrantPlugins
           machine.provider_config.functional_psf
       end
 
-      def enable(machine, folders, _opts)
-        # Export the shared folders to the VM
+      def prepare(machine, folders, _opts)
+        # Setup shared folder definitions in the VM config.
         defs = []
         folders.each do |id, data|
           hostpath = data[:hostpath]
@@ -25,7 +25,9 @@ module VagrantPlugins
         end
 
         driver(machine).share_folders(defs)
+      end
 
+      def enable(machine, folders, _opts)
         # short guestpaths first, so we don't step on ourselves
         folders = folders.sort_by do |id, data|
           if data[:guestpath]


### PR DESCRIPTION
This PR fixes a critical bag introduced in `vagrant-parallels` v2.2.0 (Linux guests only): https://github.com/Parallels/vagrant-parallels/issues/389

Changes:
1. Move shared folder setup from `enable` stage to `prepare`. In this case shared folders will be setup in the VM (via `prlctl`) before the VM is booted, so the filesystem will be available in the guest OS on early stage. 
In `virtualbox` provider it is done similarly: https://github.com/hashicorp/vagrant/blob/22795b161bf67a4c0ebbe32c9ce8777cb888c4a7/plugins/providers/virtualbox/synced_folder.rb#L17-L19

2. Add `_netdev` mount option by default to all `prl_fs` filesystems. That will prevent VM from boot failure if the shared folder (filesystem) is not available. 
`virtualbox` provider does the same for vboxfs: https://github.com/hashicorp/vagrant/blob/5b501a3fb05ed0ab16cf10991b3df9d231edb5cf/plugins/providers/virtualbox/cap/mount_options.rb#L25

From `man mount`:
> _netdev The filesystem resides on a device that requires network access (used to prevent the system from attempting to mount these filesystems until the network has been enabled on the system).



