### PR TITLE
Fixed tests and cleaned up code

### DIFF
--- a/test/unit/action/network_test.rb
+++ b/test/unit/action/network_test.rb
@@ -19,10 +19,10 @@ describe VagrantPlugins::Parallels::Action::Network do
     end
   end
 
-  let(:env)    {{ machine: machine, ui: machine.ui }}
-  let(:app)    { lambda { |*args| }}
+  let(:env) { { machine: machine, ui: machine.ui } }
+  let(:app) { ->(*args) { } }
   let(:driver) { double('driver') }
-  let(:guest)  { double('guest') }
+  let(:guest) { double('guest') }
 
   subject { described_class.new(app, env) }
 
@@ -35,7 +35,7 @@ describe VagrantPlugins::Parallels::Action::Network do
 
   it 'calls the next action in the chain' do
     called = false
-    app = lambda { |*args| called = true }
+    app = ->(*args) { called = true }
 
     action = described_class.new(app, env)
     action.call(env)
@@ -45,22 +45,22 @@ describe VagrantPlugins::Parallels::Action::Network do
 
   context 'with private network' do
     let(:virtualnets) { [] }
-    let(:bridgedifs)  { [] }
+    let(:bridgedifs) { [] }
     let(:hostonlyifs) { [] }
     let(:network_args) { {} }
 
     before do
-      machine.config.vm.network 'private_network', network_args
+      machine.config.vm.network :private_network, **network_args
       allow(driver).to receive(:read_bridged_interfaces) { bridgedifs }
       allow(driver).to receive(:read_virtual_networks) { virtualnets }
       allow(driver).to receive(:read_host_only_interfaces) { hostonlyifs }
     end
 
     context 'with type dhcp' do
-      let(:network_args) {{ type: 'dhcp' }}
+      let(:network_args) { { type: 'dhcp' } }
 
       it 'creates a host-only interface with default IP and configures network in the guest' do
-        allow(driver).to receive(:create_host_only_network) {{ name: 'vagrant-vnet0' }}
+        allow(driver).to receive(:create_host_only_network) { { name: 'vagrant-vnet0' } }
 
         subject.call(env)
 
@@ -68,9 +68,9 @@ describe VagrantPlugins::Parallels::Action::Network do
           {
             network_id: 'vagrant-vnet0',
             adapter_ip: '10.37.129.1',
-            netmask:    '255.255.255.0',
-            dhcp:       {
-              ip:    '10.37.129.1',
+            netmask: '255.255.255.0',
+            dhcp: {
+              ip: '10.37.129.1',
               lower: '10.37.129.2',
               upper: '10.37.129.254'
             }
@@ -79,22 +79,22 @@ describe VagrantPlugins::Parallels::Action::Network do
 
         expect(guest).to have_received(:capability).with(
           :configure_networks, [{
-                                  type:        :dhcp,
-                                  adapter_ip:  '10.37.129.1',
-                                  ip:          '10.37.129.1',
-                                  netmask:     '255.255.255.0',
+                                  type: :dhcp,
+                                  adapter_ip: '10.37.129.1',
+                                  ip: '10.37.129.1',
+                                  netmask: '255.255.255.0',
                                   auto_config: true,
-                                  interface:   nil
+                                  interface: nil
                                 }]
         )
       end
     end
 
     context 'with type dhcp and defined network' do
-      let(:network_args) {{ type: 'dhcp', ip: '172.28.128.100', netmask: '26' }}
+      let(:network_args) { { type: 'dhcp', ip: '172.28.128.100', netmask: '26' } }
 
       it 'creates a host-only interface with dhcp and configures network in the guest' do
-        allow(driver).to receive(:create_host_only_network) {{ name: 'vagrant-vnet0' }}
+        allow(driver).to receive(:create_host_only_network) { { name: 'vagrant-vnet0' } }
 
         subject.call(env)
 
@@ -102,9 +102,9 @@ describe VagrantPlugins::Parallels::Action::Network do
           {
             network_id: 'vagrant-vnet0',
             adapter_ip: '172.28.128.65',
-            netmask:    '26',
-            dhcp:       {
-              ip:    '172.28.128.65',
+            netmask: '26',
+            dhcp: {
+              ip: '172.28.128.65',
               lower: '172.28.128.66',
               upper: '172.28.128.126'
             }
@@ -113,27 +113,27 @@ describe VagrantPlugins::Parallels::Action::Network do
 
         expect(guest).to have_received(:capability).with(
           :configure_networks, [{
-                                  type:        :dhcp,
-                                  adapter_ip:  '172.28.128.65',
-                                  ip:          '172.28.128.100',
-                                  netmask:     '26',
+                                  type: :dhcp,
+                                  adapter_ip: '172.28.128.65',
+                                  ip: '172.28.128.100',
+                                  netmask: '26',
                                   auto_config: true,
-                                  interface:   nil
+                                  interface: nil
                                 }]
         )
       end
     end
 
     context 'with static ip' do
-      let (:network_args) {{ ip: '172.28.128.3' }}
+      let (:network_args) { { ip: '172.28.128.3' } }
 
       context 'when the desired host-only network exists' do
         let(:hostonlyifs) {
           [{
-             name:     'vagrant-vnet2',
-             ip:       '172.28.128.2',
-             netmask:  '255.255.255.0',
-             status:   'Up'
+             name: 'vagrant-vnet2',
+             ip: '172.28.128.2',
+             netmask: '255.255.255.0',
+             status: 'Up'
            }]
         }
 
@@ -143,12 +143,12 @@ describe VagrantPlugins::Parallels::Action::Network do
 
           subject.call(env)
 
-          expect(driver).not_to have_received(:create_host_only_network).with({network_id: 'vagrant-vnet2'})
+          expect(driver).not_to have_received(:create_host_only_network).with({ network_id: 'vagrant-vnet2' })
         end
       end
 
       it 'creates a host only interface and configures network in the guest' do
-        allow(driver).to receive(:create_host_only_network) {{ name: 'vagrant-vnet0' }}
+        allow(driver).to receive(:create_host_only_network) { { name: 'vagrant-vnet0' } }
 
         subject.call(env)
 
@@ -156,28 +156,28 @@ describe VagrantPlugins::Parallels::Action::Network do
           {
             network_id: 'vagrant-vnet0',
             adapter_ip: '172.28.128.1',
-            netmask:    '255.255.255.0'
+            netmask: '255.255.255.0'
           }
         )
 
         expect(guest).to have_received(:capability).with(
           :configure_networks, [{
-                                  type:        :static,
-                                  adapter_ip:  '172.28.128.1',
-                                  ip:          '172.28.128.3',
-                                  netmask:     '255.255.255.0',
+                                  type: :static,
+                                  adapter_ip: '172.28.128.1',
+                                  ip: '172.28.128.3',
+                                  netmask: '255.255.255.0',
                                   auto_config: true,
-                                  interface:   nil
+                                  interface: nil
                                 }]
         )
       end
     end
 
     context 'with static ipv6' do
-      let(:network_args) {{ ip: 'dead:beef::100' }}
+      let(:network_args) { { ip: 'dead:beef::100' } }
 
       it 'creates a host-only interface with an IPv6 address <prefix>:1' do
-        allow(driver).to receive(:create_host_only_network) {{ name: 'vagrant-vnet0' }}
+        allow(driver).to receive(:create_host_only_network) { { name: 'vagrant-vnet0' } }
         interface_ip = 'dead:beef::1'
 
         subject.call(env)
@@ -206,27 +206,27 @@ describe VagrantPlugins::Parallels::Action::Network do
 
   context 'with public network' do
     let(:virtualnets) { [] }
-    let(:bridgedifs)  { [] }
+    let(:bridgedifs) { [] }
     let(:hostonlyifs) { [] }
     let(:network_args) { {} }
 
     before do
-      machine.config.vm.network 'public_network', network_args
+      machine.config.vm.network 'public_network', **network_args
       allow(driver).to receive(:read_bridged_interfaces) { bridgedifs }
     end
 
     context 'when bridge interface is specified and available' do
-      let(:network_args) {{ type: 'dhcp', bridge: 'en0' }}
-      let(:bridgedifs)  { [{ name:'en0' }] }
+      let(:network_args) { { type: 'dhcp', bridge: 'en0' } }
+      let(:bridgedifs) { [{ name: 'en0' }] }
 
       it 'bridges to the host interface and configures network in the guest' do
         subject.call(env)
 
         expect(guest).to have_received(:capability).with(
           :configure_networks, [{
-                                  type:        :dhcp,
+                                  type: :dhcp,
                                   auto_config: true,
-                                  interface:   nil,
+                                  interface: nil,
                                   use_dhcp_assigned_default_route: false
                                 }]
         )
@@ -234,8 +234,8 @@ describe VagrantPlugins::Parallels::Action::Network do
     end
 
     context 'when bridge interface should be chosen' do
-      let(:network_args) {{ type: 'dhcp' }}
-      let(:bridgedifs)  { [{ name:'en0' }, { name: 'en1' }] }
+      let(:network_args) { { type: 'dhcp' } }
+      let(:bridgedifs) { [{ name: 'en0' }, { name: 'en1' }] }
 
       it 'bridges to the host interface and configures network in the guest' do
         allow(env[:ui]).to receive(:ask).and_return('2')
@@ -243,9 +243,9 @@ describe VagrantPlugins::Parallels::Action::Network do
         subject.call(env)
         expect(guest).to have_received(:capability).with(
           :configure_networks, [{
-                                  type:        :dhcp,
+                                  type: :dhcp,
                                   auto_config: true,
-                                  interface:   nil,
+                                  interface: nil,
                                   use_dhcp_assigned_default_route: false
                                 }]
         )
@@ -256,13 +256,13 @@ describe VagrantPlugins::Parallels::Action::Network do
 
   context 'with invalid settings' do
     [
-      { ip: 'foo'},
-      { ip: '1.2.3'},
-      { ip: 'dead::beef::'},
-      { ip: '172.28.128.3', netmask: 64},
-      { ip: '172.28.128.3', netmask: 'ffff:ffff::'},
-      { ip: 'dead:beef::', netmask: 'foo:bar::'},
-      { ip: 'dead:beef::', netmask: '255.255.255.0'}
+      { ip: 'foo' },
+      { ip: '1.2.3' },
+      { ip: 'dead::beef::' },
+      { ip: '172.28.128.3', netmask: 64 },
+      { ip: '172.28.128.3', netmask: 'ffff:ffff::' },
+      { ip: 'dead:beef::', netmask: 'foo:bar::' },
+      { ip: 'dead:beef::', netmask: '255.255.255.0' }
     ].each do |args|
       it 'raises an exception' do
         machine.config.vm.network 'private_network', **args


### PR DESCRIPTION
Due to changes, ruby 3 handles keyword arguments, `network_args` has to be passed as `**network_args`

I also added some code cleanup. The tests now run fine again.

I am new to ruby, so bear with me, if something is not right, I will make changes accordingly.