### PR TITLE
Fixed message_attribute to be kwargs #393

### DIFF
--- a/lib/vagrant-parallels/action/forward_ports.rb
+++ b/lib/vagrant-parallels/action/forward_ports.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
             # bridged networking don't require port-forwarding and establishing
             # forwarded ports on these attachment types has uncertain behaviour.
             @env[:ui].detail(I18n.t('vagrant_parallels.actions.vm.forward_ports.forwarding_entry',
-                                    message_attributes))
+                                    **message_attributes))
 
             # In Parallels Desktop the scope port forwarding rules is global,
             # so we have to keep their names unique.


### PR DESCRIPTION
This fixes the broken port forwarding of issue #393. Due to ruby3 handling kwargs differently, they now have to be passed with leading double asterisks. 

I'd recommend merging #395 first, as the test suite is also broken because of this issue.

I am new to ruby and open to any recommendations and improvements regarding this language.