### PR TITLE
Issue 401 - m1 support

### DIFF
--- a/lib/vagrant-parallels/config.rb
+++ b/lib/vagrant-parallels/config.rb
@@ -12,7 +12,6 @@ module VagrantPlugins
       attr_reader   :network_adapters
       attr_accessor :regen_src_uuid
       attr_accessor :update_guest_tools
-      attr_accessor :guest_tools_arch
 
       # Compatibility with virtualbox provider's syntax
       alias :check_guest_additions= :check_guest_tools=
@@ -28,7 +27,6 @@ module VagrantPlugins
         @name              = UNSET_VALUE
         @regen_src_uuid     = UNSET_VALUE
         @update_guest_tools = UNSET_VALUE
-        @guest_tools_arch = UNSET_VALUE
 
         network_adapter(0, :shared)
       end
@@ -83,8 +81,6 @@ module VagrantPlugins
         if @update_guest_tools == UNSET_VALUE
           @update_guest_tools = false
         end
-
-        @guest_tools_arch = nil if @guest_tools_arch == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-parallels/config.rb
+++ b/lib/vagrant-parallels/config.rb
@@ -12,6 +12,7 @@ module VagrantPlugins
       attr_reader   :network_adapters
       attr_accessor :regen_src_uuid
       attr_accessor :update_guest_tools
+      attr_accessor :guest_tools_arch
 
       # Compatibility with virtualbox provider's syntax
       alias :check_guest_additions= :check_guest_tools=
@@ -27,6 +28,7 @@ module VagrantPlugins
         @name              = UNSET_VALUE
         @regen_src_uuid     = UNSET_VALUE
         @update_guest_tools = UNSET_VALUE
+        @guest_tools_arch = UNSET_VALUE
 
         network_adapter(0, :shared)
       end
@@ -81,6 +83,8 @@ module VagrantPlugins
         if @update_guest_tools == UNSET_VALUE
           @update_guest_tools = false
         end
+
+        @guest_tools_arch = nil if @guest_tools_arch == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -434,8 +434,8 @@ module VagrantPlugins
         #
         # @param [String] guest_os Guest os type: "linux", "darwin" or "windows"
         # @return [String] Path to the ISO.
-        def read_guest_tools_iso_path(guest_os)
-          guest_os = guest_os.to_sym
+        def read_guest_tools_iso_path(guest_os, arch=nil)
+          guest_os = (guest_os + (['arm', 'arm64', 'aarch64'].include?(arch.to_s.strip) ? '_arm' : '')).to_sym
           iso_name = {
             linux: 'prl-tools-lin.iso',
             linux_arm: 'prl-tools-lin-arm.iso',

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -438,7 +438,9 @@ module VagrantPlugins
           guest_os = guest_os.to_sym
           iso_name = {
             linux: 'prl-tools-lin.iso',
+            linux_arm: 'prl-tools-lin-arm.iso',
             darwin: 'prl-tools-mac.iso',
+            darwin_arm: 'prl-tools-mac-arm.iso',
             windows: 'PTIAgent.exe'
           }
           return nil unless iso_name[guest_os]

--- a/lib/vagrant-parallels/guest_cap/darwin/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/darwin/install_parallels_tools.rb
@@ -5,11 +5,11 @@ module VagrantPlugins
 
         def self.install_parallels_tools(machine)
           machine.communicate.tap do |comm|
-            guest_os = 'darwin' + 
-                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '_arm' : '')
-            
+            arch = ''
+            comm.execute("uname -p") { |type, data| arch << data if type == :stdout }
+
             tools_iso_path = File.expand_path(
-              machine.provider.driver.read_guest_tools_iso_path(gues_os),
+              machine.provider.driver.read_guest_tools_iso_path("darwin", arch),
               machine.env.root_path
             )
             remote_file = '/tmp/prl-tools-mac.iso'

--- a/lib/vagrant-parallels/guest_cap/darwin/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/darwin/install_parallels_tools.rb
@@ -5,8 +5,11 @@ module VagrantPlugins
 
         def self.install_parallels_tools(machine)
           machine.communicate.tap do |comm|
+            guest_os = 'darwin' + 
+                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '-arm' : '')
+            
             tools_iso_path = File.expand_path(
-              machine.provider.driver.read_guest_tools_iso_path('darwin'),
+              machine.provider.driver.read_guest_tools_iso_path(gues_os),
               machine.env.root_path
             )
             remote_file = '/tmp/prl-tools-mac.iso'

--- a/lib/vagrant-parallels/guest_cap/darwin/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/darwin/install_parallels_tools.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
         def self.install_parallels_tools(machine)
           machine.communicate.tap do |comm|
             guest_os = 'darwin' + 
-                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '-arm' : '')
+                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '_arm' : '')
             
             tools_iso_path = File.expand_path(
               machine.provider.driver.read_guest_tools_iso_path(gues_os),

--- a/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
@@ -7,9 +7,12 @@ module VagrantPlugins
           if ptiagent_usable?(machine)
             machine.communicate.sudo('ptiagent-cmd --install')
           else
+            guest_os = 'linux' + 
+                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '-arm' : '')
+            
             machine.communicate.tap do |comm|
               tools_iso_path = File.expand_path(
-                machine.provider.driver.read_guest_tools_iso_path('linux'),
+                machine.provider.driver.read_guest_tools_iso_path(guest_os),
                 machine.env.root_path
               )
               remote_file = '/tmp/prl-tools-lin.iso'

--- a/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
@@ -1,3 +1,5 @@
+require 'log4r'
+
 module VagrantPlugins
   module Parallels
     module GuestLinuxCap
@@ -7,12 +9,12 @@ module VagrantPlugins
           if ptiagent_usable?(machine)
             machine.communicate.sudo('ptiagent-cmd --install')
           else
-            guest_os = 'linux' + 
-                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '_arm' : '')
-            
             machine.communicate.tap do |comm|
+              arch = ''
+              comm.execute("uname -p") { |type, data| arch << data if type == :stdout }
+
               tools_iso_path = File.expand_path(
-                machine.provider.driver.read_guest_tools_iso_path(guest_os),
+                machine.provider.driver.read_guest_tools_iso_path("linux", arch),
                 machine.env.root_path
               )
               remote_file = '/tmp/prl-tools-lin.iso'

--- a/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/install_parallels_tools.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
             machine.communicate.sudo('ptiagent-cmd --install')
           else
             guest_os = 'linux' + 
-                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '-arm' : '')
+                (['arm', 'arm64'].include?(machine.provider_config.guest_tools_arch) ? '_arm' : '')
             
             machine.communicate.tap do |comm|
               tools_iso_path = File.expand_path(

--- a/test/unit/driver/base_test.rb
+++ b/test/unit/driver/base_test.rb
@@ -1,0 +1,68 @@
+require_relative '../base'
+
+require VagrantPlugins::Parallels.source_root.join('lib/vagrant-parallels/driver/base')
+
+describe VagrantPlugins::Parallels::Driver::Base do
+  include_context 'parallels'
+  before do
+    stub_const('Vagrant::Util::Subprocess', subprocess)
+    allow(subprocess).to receive(:execute).
+        with('mdfind', any_args).
+        and_return(subprocess_result(stdout: "/application.app"))
+
+    allow(File).to receive(:exist?).with(any_args).and_return(true)
+  end
+
+  describe 'read_guest_tools_iso_path' do
+    subject(:instance) { described_class.new uuid }
+
+    it "reads `linux`:nil success" do
+      expect(instance.read_guest_tools_iso_path('linux')).to end_with('prl-tools-lin.iso')
+    end
+    it "reads `linux`:`x86_64` success" do
+      expect(instance.read_guest_tools_iso_path('linux', 'x86_64')).to end_with('prl-tools-lin.iso')
+    end
+    it "reads `linux`:`aarch64` success" do
+      expect(instance.read_guest_tools_iso_path('linux', 'aarch64')).to end_with('prl-tools-lin-arm.iso')
+    end
+    it "reads `linux`:`arm64` success" do
+      expect(instance.read_guest_tools_iso_path('linux', 'arm64')).to end_with('prl-tools-lin-arm.iso')
+    end
+
+    it "reads `darwin`:nil success" do
+      expect(instance.read_guest_tools_iso_path('darwin')).to end_with('prl-tools-mac.iso')
+    end
+    it "reads `darwin`:`x86_64` success" do
+      expect(instance.read_guest_tools_iso_path('darwin', 'x86_64')).to end_with('prl-tools-mac.iso')
+    end
+    it "reads `darwin`:`aarch64` success" do
+      expect(instance.read_guest_tools_iso_path('darwin', 'aarch64')).to end_with('prl-tools-mac-arm.iso')
+    end
+    it "reads `darwin`:`arm64` success" do
+      expect(instance.read_guest_tools_iso_path('darwin', 'arm64')).to end_with('prl-tools-mac-arm.iso')
+    end
+    it "reads `darwin`:`arm` success" do
+      expect(instance.read_guest_tools_iso_path('darwin', 'arm')).to end_with('prl-tools-mac-arm.iso')
+    end
+
+    it "reads `windows`:nil success" do
+      expect(instance.read_guest_tools_iso_path('windows')).to end_with('PTIAgent.exe')
+    end
+    it "reads `windows`:`x86_64` success" do
+      expect(instance.read_guest_tools_iso_path('windows')).to end_with('PTIAgent.exe')
+    end
+    it "reads `windows`:`aarch64` success" do
+      expect(instance.read_guest_tools_iso_path('windows')).to end_with('PTIAgent.exe')
+    end
+    
+    it "reads `unknown`:nil success" do
+      expect(instance.read_guest_tools_iso_path('unknown')).to eq(nil)
+    end
+    
+    it "reads `linux`:nil exception" do
+      VagrantPlugins::Parallels::Plugin.setup_i18n
+      allow(File).to receive(:exist?).and_return(false)
+      expect(instance.read_guest_tools_iso_path('linux')).to raise_exception
+    end
+  end
+end

--- a/test/unit/driver/base_test.rb
+++ b/test/unit/driver/base_test.rb
@@ -62,7 +62,7 @@ describe VagrantPlugins::Parallels::Driver::Base do
     it "reads `linux`:nil exception" do
       VagrantPlugins::Parallels::Plugin.setup_i18n
       allow(File).to receive(:exist?).and_return(false)
-      expect(instance.read_guest_tools_iso_path('linux')).to raise_exception
+      expect { instance.read_guest_tools_iso_path('linux') }.to raise_exception
     end
   end
 end


### PR DESCRIPTION
Implements arm (aarch) determination support for installing the correct Parallels Tools ISO on linux & darwin guests.
Requests the arch directly from the guest using `uname` over the SSH connection. Adds basic unit tests for the updated `read_guest_tools_iso_path` function.