### PR TITLE
[docs] Hotfix for newlines and whitespaces

### DIFF
--- a/website/docs/source/docs/boxes/index.html.md
+++ b/website/docs/source/docs/boxes/index.html.md
@@ -33,12 +33,14 @@ $ vagrant box add bento/ubuntu-18.04
 
 You can also quickly initialize a Vagrant environment with the command:
 
-For Macs with Intel chip:
+- For Macs with Intel chip:
+
 ```
 $ vagrant init bento/ubuntu-18.04
 ...
 ```
-For Macs with Apple M-series chip:
+
+- For Macs with Apple M-series chip:
 
 ```
 $ vagrant init bento/ubuntu-20.04-arm64

--- a/website/docs/source/docs/getting-started.html.md
+++ b/website/docs/source/docs/getting-started.html.md
@@ -22,12 +22,15 @@ it using Vagrant. The following describes how to create a virtual machine.
 
 Create a new directory and init the new Vagrant project in it:
 
-For Macs with Intel chip:
+- For Macs with Intel chip:
+
 ```
 $ vagrant init bento/ubuntu-18.04
 $ vagrant up --provider=parallels
 ```
-For Macs with Apple M-series chip:
+
+- For Macs with Apple M-series chip:
+
 ```
 $ vagrant init bento/ubuntu-20.04-arm64
 $ vagrant up --provider=parallels

--- a/website/docs/source/docs/usage.html.md
+++ b/website/docs/source/docs/usage.html.md
@@ -13,17 +13,20 @@ When Parallels provider is installed it has a higher priority than any other
 provider shipped with Vagrant. In most cases you will not have to specify the
 provider name, just "vagrant up" will be enough:
 
-For Macs with Intel chip:
+- For Macs with Intel chip:
+
 ```
 $ vagrant init bento/ubuntu-18.04
 $ vagrant up
 ```
 
-For Macs with Apple M-series chip:
+- For Macs with Apple M-series chip:
+
 ```
 $ vagrant init bento/ubuntu-20.04-arm64
 $ vagrant up
 ```
+
 But if you have a multi-provider configuration and/or want to be sure that
 exactly `parallels` provider will be used, then you can specify it explicitly:
 


### PR DESCRIPTION
This is a hotfix in addition to https://github.com/Parallels/vagrant-parallels/pull/436
Due to the imperfections in our current static website generator (`middleman`) we have to add newlines before every code snippet block.

JFYI, @sai-kumar-peddireddy 