### PR TITLE
Fix compatibility with both Ruby 2.7 and Ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'https://github.com/hashicorp/vagrant.git', branch: 'main'
+  gem 'vagrant', git: 'https://github.com/hashicorp/vagrant.git', tag: 'v2.3.4'
 
-  gem 'vagrant-spec', git: 'https://github.com/hashicorp/vagrant-spec.git', branch: 'main'
+  # TODO: Switch back to the upstream from `hashicorp` org when this PR is merged:
+  # https://github.com/hashicorp/vagrant-spec/pull/56
+  gem 'vagrant-spec', git: 'https://github.com/legal90/vagrant-spec.git', branch: 'fix-ruby-3'
 end

--- a/vagrant-parallels.gemspec
+++ b/vagrant-parallels.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.11'
   spec.add_development_dependency 'rspec-its', '~> 1.3.0'
+  spec.add_development_dependency 'webrick', '~> 1.8.0'
 
   spec.files = Dir['lib/**/*', 'locales/**/*', 'README.md', 'CHANGELOG.md', 'LICENSE.txt']
   spec.require_path = 'lib'

--- a/vagrant-parallels.gemspec
+++ b/vagrant-parallels.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/Parallels/vagrant-parallels'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version     = '>= 3.0', '< 3.3'
   spec.required_rubygems_version = '>= 1.3.6'
   spec.rubyforge_project         = 'vagrant-parallels'
 


### PR DESCRIPTION
- [gemspec: Add webrick dependency](https://github.com/Parallels/vagrant-parallels/commit/cfcb78c3faab8c91a36e92dd1cfca0ba53584e42) 
It is not included in Ruby 3.0 standard lib anymore, so we should add it explicitly

- [gemspec: Fix compatibility with Ruby 2.7 and older](https://github.com/Parallels/vagrant-parallels/commit/7fff7c09f3a409caae0fb6c3f9a840c6e5498723) 
Vagrant 2.3.* is still using Ruby 2.7 as the embedded ruby interpreter. We should not include a strict "required_ruby_version"
in our gemfile, otherwise it won't be possible to install our plugin on Vagrant 2.3* or older.
It's better to remove the line completely and rely on the compatibility defined by the upstream Vagrant.

- [Gemfile: Update dev dependencies](https://github.com/Parallels/vagrant-parallels/commit/9ee6da376e37bdfdd78f09998fb7075ebfe815ab) 
  - Pin `vagrant` to the latest release tag `v2.3.4`. Current `main` branch has unreleased changes which brakes our
acceptance tests. Ref: https://github.com/hashicorp/vagrant/pull/13052#issuecomment-1479514746
  - Pin `vagrant-spec` to a PR branch, which contains the fix for Ruby 3.0 runtime:
https://github.com/hashicorp/vagrant-spec/pull/56