### PR TITLE
driver: Fix the detection of VM IP using prlctl command

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -786,7 +786,9 @@ module VagrantPlugins
             sleep 2
           end
 
-          return ''
+          # We didn't manage to determine IP - return nil and
+          # expect SSH client to do a retry
+          return nil
         end
 
         # Reads the SSH port of this VM.


### PR DESCRIPTION
It completes the fix introduced in https://github.com/Parallels/vagrant-parallels/pull/434

The previous statement with `||` operator always returned empty string if it was returned by `read_guest_ip_dhcp`. Now we are checking the result properly.
Also, I added the loop to make sure that we wait for the real IP instead of returning `''` expecting the SSH client to retry.