### PR TITLE
445 vagrant up exits with status 1 for macvms

### DIFF
--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -4,7 +4,6 @@ module VagrantPlugins
   module Parallels
     module Action
       class Import
-        include VagrantPlugins::Parallels::Util::Common
         @@lock = Mutex.new
 
         def initialize(app, env)
@@ -26,7 +25,7 @@ module VagrantPlugins
 
           # Linked clones are supported only for PD 11 and higher
           # Linked clones are not supported in macvms
-          if env[:machine].provider_config.linked_clone and !is_macvm(env)
+          if env[:machine].provider_config.linked_clone and !Util::Common::is_macvm(env[:machine])
             # Linked clone creation should not be concurrent [GH-206]
             options[:snapshot_id] = env[:clone_snapshot_id]
             options[:linked] = true

--- a/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
+++ b/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
@@ -6,7 +6,6 @@ module VagrantPlugins
   module Parallels
     module Action
       class PrepareCloneSnapshot
-        include VagrantPlugins::Parallels::Util::Common
         @@lock = Mutex.new
 
         def initialize(app, env)
@@ -20,7 +19,7 @@ module VagrantPlugins
             return @app.call(env)
           end
 
-          if is_macvm(env)
+          if Util::Common::is_macvm(env[:machine])
             #Ignore, since macvms doesn't support snapshot creation
             @logger.info('Snapshot creation is not supported yet for macOS ARM Guests, skip snapshot preparing')
             return @app.call(env)

--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -4,7 +4,6 @@ module VagrantPlugins
   module Parallels
     module Action
       class SaneDefaults
-        include VagrantPlugins::Parallels::Util::Common
 
         def initialize(app, env)
           @logger = Log4r::Logger.new('vagrant_parallels::action::sanedefaults')
@@ -30,7 +29,7 @@ module VagrantPlugins
 
         def default_settings
           # Options defined below are not supported for `*.macvm` VMs
-          return {} if is_macvm(@env)
+          return {} if Util::Common::is_macvm(@env[:machine])
 
           {
             tools_autoupdate: 'no',

--- a/lib/vagrant-parallels/synced_folder.rb
+++ b/lib/vagrant-parallels/synced_folder.rb
@@ -28,6 +28,11 @@ module VagrantPlugins
       end
 
       def enable(machine, folders, _opts)
+        # Skip executing these steps for Mac OS VMs running in M series Chips
+        if Util::Common::is_macvm(machine)
+          return
+        end
+
         # short guestpaths first, so we don't step on ourselves
         folders = folders.sort_by do |id, data|
           if data[:guestpath]
@@ -77,7 +82,8 @@ module VagrantPlugins
       end
 
       def disable(machine, folders, _opts)
-        if machine.guest.capability?(:unmount_parallels_shared_folder)
+        # Skip executing unmounting steps for Mac OS VMs running in M series Chips
+        if machine.guest.capability?(:unmount_parallels_shared_folder) && !Util::Common::is_macvm(machine)
           folders.each do |id, data|
             machine.guest.capability(
               :unmount_parallels_shared_folder,

--- a/lib/vagrant-parallels/util/common.rb
+++ b/lib/vagrant-parallels/util/common.rb
@@ -5,8 +5,8 @@ module VagrantPlugins
 
         # Determines whether the VM's box contains a macOS guest for an Apple Silicon host.
         # In this case the image file ends with '.macvm' instead of '.pvm'
-        def is_macvm(env)
-          return !!Dir.glob(env[:machine].box.directory.join('*.macvm')).first
+        def self.is_macvm(machine)
+          return !!Dir.glob(machine.box.directory.join('*.macvm')).first
         end
 
       end


### PR DESCRIPTION
Made is_macvm a member of module since I was getting error in accessing the function from guest_cap. Since macvm is actually a darwin guest, darwin guest commands to share folders are getting executed. I skipped this in enable & disable functions for macvms. 

@legal90 We need these changes within a week. Please review. 