### PR TITLE
Add a placeholder synced folder class for Mac VMs

### DIFF
--- a/lib/vagrant-parallels/action/import.rb
+++ b/lib/vagrant-parallels/action/import.rb
@@ -4,7 +4,6 @@ module VagrantPlugins
   module Parallels
     module Action
       class Import
-        include VagrantPlugins::Parallels::Util::Common
         @@lock = Mutex.new
 
         def initialize(app, env)
@@ -26,7 +25,7 @@ module VagrantPlugins
 
           # Linked clones are supported only for PD 11 and higher
           # Linked clones are not supported in macvms
-          if env[:machine].provider_config.linked_clone and !is_macvm(env)
+          if env[:machine].provider_config.linked_clone and !Util::Common::is_macvm(env[:machine])
             # Linked clone creation should not be concurrent [GH-206]
             options[:snapshot_id] = env[:clone_snapshot_id]
             options[:linked] = true

--- a/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
+++ b/lib/vagrant-parallels/action/prepare_clone_snapshot.rb
@@ -6,7 +6,6 @@ module VagrantPlugins
   module Parallels
     module Action
       class PrepareCloneSnapshot
-        include VagrantPlugins::Parallels::Util::Common
         @@lock = Mutex.new
 
         def initialize(app, env)
@@ -20,7 +19,7 @@ module VagrantPlugins
             return @app.call(env)
           end
 
-          if is_macvm(env)
+          if Util::Common::is_macvm(env[:machine])
             #Ignore, since macvms doesn't support snapshot creation
             @logger.info('Snapshot creation is not supported yet for macOS ARM Guests, skip snapshot preparing')
             return @app.call(env)

--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -4,7 +4,6 @@ module VagrantPlugins
   module Parallels
     module Action
       class SaneDefaults
-        include VagrantPlugins::Parallels::Util::Common
 
         def initialize(app, env)
           @logger = Log4r::Logger.new('vagrant_parallels::action::sanedefaults')
@@ -30,7 +29,7 @@ module VagrantPlugins
 
         def default_settings
           # Options defined below are not supported for `*.macvm` VMs
-          return {} if is_macvm(@env)
+          return {} if Util::Common::is_macvm(@env[:machine])
 
           {
             tools_autoupdate: 'no',

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -108,6 +108,11 @@ module VagrantPlugins
         SyncedFolderMacVM
       end
 
+      synced_folder_capability(:parallels_macvm, "mount_name") do
+        require_relative "cap/mount_options"
+        SyncedFolderCap::MountOptions
+      end
+
       synced_folder_capability(:parallels, "mount_name") do
         require_relative "cap/mount_options"
         SyncedFolderCap::MountOptions

--- a/lib/vagrant-parallels/plugin.rb
+++ b/lib/vagrant-parallels/plugin.rb
@@ -103,6 +103,11 @@ module VagrantPlugins
         SyncedFolder
       end
 
+      synced_folder(:parallels_macvm) do
+        require_relative 'synced_folder_macvm'
+        SyncedFolderMacVM
+      end
+
       synced_folder_capability(:parallels, "mount_name") do
         require_relative "cap/mount_options"
         SyncedFolderCap::MountOptions

--- a/lib/vagrant-parallels/synced_folder.rb
+++ b/lib/vagrant-parallels/synced_folder.rb
@@ -4,9 +4,10 @@ module VagrantPlugins
   module Parallels
     class SyncedFolder < Vagrant.plugin('2', :synced_folder)
       def usable?(machine, raise_errors=false)
-        # These synced folders only work if the provider is Parallels
+        # These synced folders only work if the provider is Parallels and the guest is not *.macvm
         machine.provider_name == :parallels &&
-          machine.provider_config.functional_psf
+          machine.provider_config.functional_psf &&
+          !Util::Common::is_macvm(machine)
       end
 
       def prepare(machine, folders, _opts)

--- a/lib/vagrant-parallels/synced_folder_macvm.rb
+++ b/lib/vagrant-parallels/synced_folder_macvm.rb
@@ -1,0 +1,32 @@
+require 'vagrant/util/platform'
+
+module VagrantPlugins
+  module Parallels
+    class SyncedFolderMacVM < Vagrant.plugin('2', :synced_folder)
+      def usable?(machine, raise_errors=false)
+        # These synced folders only work if the provider is Parallels and the guest is *.macvm
+        machine.provider_name == :parallels && Util::Common::is_macvm(machine)
+      end
+
+      def prepare(machine, folders, _opts)
+        # TBD: Synced folders for *.macvm are not implemented yet
+        return
+      end
+
+      def enable(machine, folders, _opts)
+        # TBD: Synced folders for *.macvm are not implemented yet
+        return
+      end
+
+      def disable(machine, folders, _opts)
+        # TBD: Synced folders for *.macvm are not implemented yet
+        return
+      end
+
+      def cleanup(machine, opts)
+        # TBD: Synced folders for *.macvm are not implemented yet
+        return
+      end
+    end
+  end
+end

--- a/lib/vagrant-parallels/util/common.rb
+++ b/lib/vagrant-parallels/util/common.rb
@@ -5,8 +5,8 @@ module VagrantPlugins
 
         # Determines whether the VM's box contains a macOS guest for an Apple Silicon host.
         # In this case the image file ends with '.macvm' instead of '.pvm'
-        def is_macvm(env)
-          return !!Dir.glob(env[:machine].box.directory.join('*.macvm')).first
+        def self.is_macvm(machine)
+          return !!Dir.glob(machine.box.directory.join('*.macvm')).first
         end
 
       end


### PR DESCRIPTION
This is the alternative implementation of #446, which is supposed to fix the current issue of mounting synced folders on *.macvm guests: #445 

Here I moved the synced folder support for *macvm to a separate class, `SyncedFolderMacVM`. It is just a placeholder for now and should still be filled with the proper implementation for macvms, as it was discussed here: https://github.com/Parallels/vagrant-parallels/pull/446#issuecomment-1554461800

Fixes #445 
Closes #446 as superseded 