### PR TITLE
correct vagrant package

### DIFF
--- a/lib/vagrant-parallels/action/export.rb
+++ b/lib/vagrant-parallels/action/export.rb
@@ -61,7 +61,8 @@ module VagrantPlugins
           env[:ui].info I18n.t('vagrant.actions.vm.export.exporting')
 
           options = {
-            dst: env['export.temp_dir'].to_s
+            dst: env['export.temp_dir'].to_s,
+            linked: true,
           }
 
           env[:package_box_id] = env[:machine].provider.driver.clone_vm(


### PR DESCRIPTION
Following commit https://github.com/sony-aufsehe/vagrant-parallels/commit/dbe3495cd3fbf09642cbd21f602bf8280c12d6d2, `vagrant package` fails. This is due to the new copy method introduced in the commit. The new method performs an additional unregister. While this is okay for an import action, The driver copy method is also used in export action an the export method expect the src vm to still be registered after copy.

Passing the option linked to the call to `clone_vm` allows to fallback in the original copy behaviour. Thus effectively restoring package functionality.

EDIT: address issue #461 