### PR TITLE
Revert "use clonefile copy for macvm boxes"

### DIFF
--- a/lib/vagrant-parallels/util/common.rb
+++ b/lib/vagrant-parallels/util/common.rb
@@ -1,5 +1,3 @@
-require 'shellwords'
-
 module VagrantPlugins
   module Parallels
     module Util
@@ -11,23 +9,6 @@ module VagrantPlugins
           return !machine.box.nil? && !!Dir.glob(machine.box.directory.join('*.macvm')).first
         end
 
-        # Determines if the box directory is on an APFS filesystem
-        def self.is_apfs?(path, &block)
-            output = {stdout: '', stderr: ''}
-            df_command = %w[df -T apfs]
-            df_command << Shellwords.escape(path)
-            execute(*df_command, &block).exit_code == 0
-        end
-
-        private
-
-        def self.execute(*command, &block)
-          command << { notify: [:stdout, :stderr] }
-
-          Vagrant::Util::Busy.busy(lambda {}) do
-            Vagrant::Util::Subprocess.execute(*command, &block)
-          end
-        end
       end
     end
   end

--- a/test/unit/support/shared/pd_driver_examples.rb
+++ b/test/unit/support/shared/pd_driver_examples.rb
@@ -112,24 +112,7 @@ shared_examples 'parallels desktop driver' do |options|
   end
 
   describe 'clone_vm' do
-    before do
-      expect(subprocess).to receive(:execute).twice.
-        with('prlctl', 'list', '--json', '-i', an_instance_of(String),
-             an_instance_of(Hash)).
-        and_return(subprocess_result(stdout: '[{"Home": "/home/some/path"}]', exit_code: 0))
-      expect(subprocess).to receive(:execute).
-        with('prlctl', 'list', '--all', '--no-header', '--json', '-o', 'name,uuid', {:notify=>[:stdout, :stderr]}).
-        and_return(subprocess_result(stdout: '[]', exit_code: 0))
-      expect(subprocess).to receive(:execute).
-        with('prlctl', 'list', '--all', '--no-header', '--json', '-o', 'name,uuid', '--template', {:notify=>[:stdout, :stderr]}).
-        and_return(subprocess_result(stdout: '[]', exit_code: 0))
-    end
-
-    it 'clones VM to the new one when not on APFS' do
-      expect(subprocess).to receive(:execute).
-        with('df', '-T', 'apfs', '/home/some/path',
-             an_instance_of(Hash)).
-        and_return(subprocess_result(exit_code: 1))
+    it 'clones VM to the new one' do
       expect(subprocess).to receive(:execute).
         with('prlctl', 'clone', tpl_uuid, '--name', an_instance_of(String),
              an_instance_of(Hash)).
@@ -137,31 +120,7 @@ shared_examples 'parallels desktop driver' do |options|
       subject.clone_vm(tpl_uuid)
     end
 
-    it 'uses cp to clone VM to the new one when on APFS' do
-      expect(subprocess).to receive(:execute).
-        with('df', '-T', 'apfs', '/home/some/path',
-             an_instance_of(Hash)).
-        and_return(subprocess_result(exit_code: 0))
-      expect(subprocess).to receive(:execute).
-        with('cp', '-c', '-R', '-p', '/home/some/path', an_instance_of(String),
-             an_instance_of(Hash)).
-        and_return(subprocess_result(exit_code: 0))
-      expect(subprocess).to receive(:execute).
-        with('prlctl', 'register', an_instance_of(String),
-             an_instance_of(Hash)).
-        and_return(subprocess_result(exit_code: 0))
-      expect(subprocess).to receive(:execute).
-        with('prlctl', 'unregister', tpl_uuid, an_instance_of(Hash)).
-        and_return(subprocess_result(exit_code: 0))
-      expect(driver).to receive(:update_vm_name).and_return(true)
-      subject.clone_vm(tpl_uuid)
-    end
-
     it 'clones VM to the exported VM' do
-      expect(subprocess).to receive(:execute).
-        with('df', '-T', 'apfs', '/home/some/path',
-             an_instance_of(Hash)).
-        and_return(subprocess_result(exit_code: 1))
       expect(subprocess).to receive(:execute).
         with('prlctl', 'clone', uuid, '--name', an_instance_of(String),
              '--dst', an_instance_of(String), an_instance_of(Hash)).


### PR DESCRIPTION
This reverts commit dbe3495cd3fbf09642cbd21f602bf8280c12d6d2.

Native copy is implemented in Parallels Desktop 19.2.1. Users can now update to latest version & use this feature. 