### PR TITLE
Support guest tools updates on Windows again (for ARM also)

### DIFF
--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -463,7 +463,14 @@ module VagrantPlugins
           iso_path = File.expand_path("./Contents/Resources/Tools/#{iso_name[guest_os]}",
                                       bundle_path.split("\n")[0])
 
-          raise Errors::ParallelsToolsIsoNotFound, iso_path: iso_path unless File.exist?(iso_path)
+          unless File.exist?(iso_path)
+            if guest_os == :windows
+              # Fallback to exe tools package for older versions of Paralles
+              iso_path = File.expand_path("./Contents/Resources/Tools/PTIAgent.exe", bundle_path.split("\n")[0])
+            end
+
+            raise Errors::ParallelsToolsIsoNotFound, iso_path: iso_path unless File.exist?(iso_path)
+          end
 
           iso_path
         end

--- a/lib/vagrant-parallels/driver/base.rb
+++ b/lib/vagrant-parallels/driver/base.rb
@@ -453,7 +453,8 @@ module VagrantPlugins
             linux_arm: 'prl-tools-lin-arm.iso',
             darwin: 'prl-tools-mac.iso',
             darwin_arm: 'prl-tools-mac-arm.iso',
-            windows: 'PTIAgent.exe'
+            windows: 'prl-tools-win.iso',
+            windows_arm: 'prl-tools-win-arm.iso',
           }
           return nil unless iso_name[guest_os]
 

--- a/lib/vagrant-parallels/guest_cap/windows/install_parallels_tools.rb
+++ b/lib/vagrant-parallels/guest_cap/windows/install_parallels_tools.rb
@@ -4,22 +4,30 @@ module VagrantPlugins
       class InstallParallelsTools
         def self.install_parallels_tools(machine)
           machine.communicate.tap do |comm|
+            # Get the host arch. This is safe even if an older x86-only Vagrant version is used.
+            arch = `arch -64 uname -m`.chomp
+
             pti_agent_path = File.expand_path(
-              machine.provider.driver.read_guest_tools_iso_path('windows'),
+              machine.provider.driver.read_guest_tools_iso_path('windows', arch),
               machine.env.root_path
             )
 
-            remote_file = '$env:TEMP\PTIAgent.exe'
+            remote_file = '$env:TEMP\parallels-tools-win.iso'
             comm.upload(pti_agent_path, remote_file)
 
             install_script = <<-EOH
-            Start-Process -FilePath #{remote_file} `
+            $MountedISOs=Mount-DiskImage -PassThru #{remote_file}
+            $Volume=$MountedISOs | Get-Volume
+            $DriveLetter=$Volume.DriveLetter
+
+            Start-Process -FilePath ($DriveLetter + ":/PTAgent.exe") `
               -ArgumentList "/install_silent" `
               -Verb RunAs `
               -Wait
             EOH
 
             cleanup_script = <<-EOH
+            Dismount-DiskImage -ImagePath #{remote_file}
             If (Test-Path #{remote_file}){
               Remove-Item #{remote_file}
             }

--- a/test/unit/driver/base_test.rb
+++ b/test/unit/driver/base_test.rb
@@ -46,19 +46,19 @@ describe VagrantPlugins::Parallels::Driver::Base do
     end
 
     it "reads `windows`:nil success" do
-      expect(instance.read_guest_tools_iso_path('windows')).to end_with('PTIAgent.exe')
+      expect(instance.read_guest_tools_iso_path('windows')).to end_with('prl-tools-win.iso')
     end
     it "reads `windows`:`x86_64` success" do
-      expect(instance.read_guest_tools_iso_path('windows')).to end_with('PTIAgent.exe')
+      expect(instance.read_guest_tools_iso_path('windows', 'x86_64')).to end_with('prl-tools-win.iso')
     end
     it "reads `windows`:`aarch64` success" do
-      expect(instance.read_guest_tools_iso_path('windows')).to end_with('PTIAgent.exe')
+      expect(instance.read_guest_tools_iso_path('windows', 'aarch64')).to end_with('prl-tools-win-arm.iso')
     end
-    
+
     it "reads `unknown`:nil success" do
       expect(instance.read_guest_tools_iso_path('unknown')).to eq(nil)
     end
-    
+
     it "reads `linux`:nil exception" do
       VagrantPlugins::Parallels::Plugin.setup_i18n
       allow(File).to receive(:exist?).and_return(false)


### PR DESCRIPTION
Looks like at some point PTIAgent.exe was removed from the Parallels Desktop app bundle and so this plugin updating tools on Windows no longer works.

The current tools distribution for Windows is via ISOs in the app bundle now just as Linux and Mac are. We can copy the ISO and mount it with Powershell, then execute the updater.

Tested this with Parallels 19 and Windows 11 22h2 image with an outdated tools from earlier 19.x releases.

```
==> win11-22h2-arm: Booting VM...
==> win11-22h2-arm: Waiting for machine to boot. This may take a few minutes...
    win11-22h2-arm: SSH address: fe80::db6b:6e69:542c:9439:22
    win11-22h2-arm: SSH username: vagrant
    win11-22h2-arm: SSH auth method: private key
    win11-22h2-arm: Warning: Host unreachable. Retrying...
    win11-22h2-arm: Warning: Connection refused. Retrying...
==> win11-22h2-arm: Machine booted and ready!
==> win11-22h2-arm: Checking for Parallels Tools installed on the VM...
==> win11-22h2-arm: Parallels Tools installed on this VM are outdated! In most cases
==> win11-22h2-arm: this is fine but in rare cases it can cause things such as shared
==> win11-22h2-arm: folders to not work properly. If you see shared folder errors,
==> win11-22h2-arm: please update Parallels Tools within the virtual machine and
==> win11-22h2-arm: reload your VM.
==> win11-22h2-arm: Installing the proper version of Parallels Tools. This may take a few minutes...
==> win11-22h2-arm: Parallels Tools have been installed. Rebooting the VM...
==> win11-22h2-arm: Attempting graceful shutdown of VM...
==> win11-22h2-arm: Running 'pre-boot' VM customizations...
==> win11-22h2-arm: Booting VM...
==> win11-22h2-arm: Waiting for machine to boot. This may take a few minutes...
==> win11-22h2-arm: Machine booted and ready!
```

And when it came back up, tools install was good.