### PR TITLE
corrected time_sync configuration to time_sync_smart_mode

### DIFF
--- a/lib/vagrant-parallels/action/sane_defaults.rb
+++ b/lib/vagrant-parallels/action/sane_defaults.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
             sh_app_guest_to_host: 'off',
             sh_app_host_to_guest: 'off',
             startup_view: 'headless',
-            time_sync: 'on',
+            time_sync_smart_mode: 'on',
             disable_timezone_sync: 'on',
             shf_host_defined: 'off'
           }


### PR DESCRIPTION
fixes Unrecognized option: --time-sync 

```
There was an error while command execution. The command and stderr is shown below.
 
Command: ["/usr/local/bin/prlctl", "set", "7bd2de5a-6a02-41ab-a1aa-5bb9b7d6567e", "--time-sync", "on"]
 
Stderr: Unrecognized option: --time-sync
```

by correcting `--time-sync` to `--time-sync-smart-mode`