### PR TITLE
Add an AddArmor override rule before mounting FUSE 3 filesystems

### DIFF
--- a/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
@@ -67,6 +67,20 @@ module VagrantPlugins
           # Create the guest path if it doesn't exist
           machine.communicate.sudo("mkdir -p #{guest_path}")
 
+          # On Ubuntu 26.04+, AppArmor's fusermount3 profile blocks FUSE mounts by default.
+          # Add an override rule for this mountpoint and reload the profile.
+          # AppArmor requires a trailing slash on directory paths in mount rules.
+          apparmor_mountpoint = guestpath.end_with?('/') ? guestpath : "#{guestpath}/"
+          apparmor_setup = <<-CMD
+            if [ -f /usr/bin/prl_fsd ] && [ -f /etc/apparmor.d/fusermount3 ]; then
+              mkdir -p /etc/apparmor.d/local
+              rule="mount fstype=@{fuse_types} -> #{apparmor_mountpoint},"
+              grep -qF "$rule" /etc/apparmor.d/local/fusermount3 2>/dev/null || echo "$rule" >> /etc/apparmor.d/local/fusermount3
+              apparmor_parser -r /etc/apparmor.d/fusermount3
+            fi
+          CMD
+          machine.communicate.sudo(apparmor_setup)
+
           # Attempt to mount the folder. We retry here a few times because
           # it can fail early on.
           stderr = ""


### PR DESCRIPTION
Ubuntu 26.04 (maybe earlier versions already?) ships with an AppArmor profile for `fusermount3` that blocks FUSE mounts by default. This causes `prl_fsd`-based shared folder mounts to fail with `permission denied` upon boot (#522).

I have noticed that the override file already contains two lines:

```
mount fstype=@{fuse_types} options=(nosuid,nodev,rw,noatime) -> /media/{,**/},
mount fstype=@{fuse_types} options=(nosuid,nodev,ro,noatime) -> /media/{,**/},
```

I am not sure where those come from, but it might be that those are added by Parallels Tools to address https://forum.parallels.com/threads/ubuntu-25-04.367139/. In that case, I'd say adding extra lines for those mounts is a perfect fit.