### PR TITLE
Only pass 'big_writes' FUSE mount option on libfuse2 guests

### DIFF
--- a/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
+++ b/lib/vagrant-parallels/guest_cap/linux/mount_parallels_shared_folder.rb
@@ -43,7 +43,17 @@ module VagrantPlugins
 
           prl_fsd_mount_options = mount_options.split(',').reject { |opt| opt == '_netdev' }
 
-          prl_fsd_mount_options << "big_writes"
+          # The `big_writes` mount option was removed in libfuse3 (guests that
+          # ship `fusermount3`, e.g. Ubuntu 24.04+), since big writes have been
+          # negotiated automatically via the FUSE_BIG_WRITES capability since
+          # Linux kernel 2.6.26. Passing it on a libfuse3 guest causes prl_fsd
+          # to fail outright with:
+          #   fuse: unknown option(s): `-o big_writes'
+          # On libfuse2 guests (only `fusermount`, no `fusermount3` binary) the
+          # option is still the way to opt in to larger write sizes, so keep
+          # passing it there for backwards compatibility (e.g. Ubuntu 18.04).
+          uses_fuse3 = machine.communicate.test("command -v fusermount3")
+          prl_fsd_mount_options << "big_writes" unless uses_fuse3
           prl_fsd_mount_options << "fsname=#{name}"
           prl_fsd_mount_options << "subtype=prl_fsd"
 


### PR DESCRIPTION
libfuse3 removed the 'big_writes' mount option since big writes have been negotiated automatically via FUSE_BIG_WRITES since Linux kernel 2.6.26. Passing it on guests using libfuse3 (e.g. Ubuntu 24.04+, which ships fusermount3) causes prl_fsd to fail with:

    fuse: unknown option(s): `-o big_writes'

which breaks 'vagrant up'/'vagrant reload' shared folder mounting entirely on those guests.

This detects libfuse3 via the presence of the fusermount3 binary and skips the option only in that case, preserving the existing behavior (and its write-throughput benefit) on older libfuse2 guests such as Ubuntu 18.04.

Tested on: Ubuntu 24.04 LTS arm64, kernel 6.8.0-101-generic, Parallels Guest Tools 27.0.0.58628.